### PR TITLE
Remove interface for `long double` functions

### DIFF
--- a/include/internal/concepts.h
+++ b/include/internal/concepts.h
@@ -1,0 +1,14 @@
+
+#pragma once
+
+#include <type_traits>
+
+namespace xtd {
+
+  template <typename T>
+  concept Numeric = requires {
+    std::is_arithmetic_v<T>;
+    requires sizeof(T) <= 8;
+  };
+
+}  // namespace xtd

--- a/include/math/abs.h
+++ b/include/math/abs.h
@@ -19,7 +19,7 @@ namespace xtd {
     return ::abs(x);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::abs(x);
+    return sycl::fabs(x);
 #else
     // standard C++ code
     return std::abs(x);
@@ -35,7 +35,7 @@ namespace xtd {
     return ::abs(x);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::abs(x);
+    return sycl::fabs(x);
 #else
     // standard C++ code
     return std::abs(x);

--- a/include/math/abs.h
+++ b/include/math/abs.h
@@ -10,70 +10,69 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T abs(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float abs(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::abs(x);
+    // CUDA device code
+    return ::abs(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::abs(x);
+    // HIP/ROCm device code
+    return ::abs(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::abs(x);
+    // SYCL device code
+    return sycl::abs(x);
 #else
-  // standard C++ code
-  return std::abs(x);
+    // standard C++ code
+    return std::abs(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float fabsf(float x) {
+  XTD_DEVICE_FUNCTION inline constexpr double abs(double x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::fabsf(x);
+    // CUDA device code
+    return ::abs(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::fabsf(x);
+    // HIP/ROCm device code
+    return ::abs(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::fabsf(x);
+    // SYCL device code
+    return sycl::abs(x);
 #else
-  // standard C++ code
-  return fabsf(x);
+    // standard C++ code
+    return std::abs(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double fabsl(long double x) {
+  XTD_DEVICE_FUNCTION inline constexpr float fabsf(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::fabsl(x);
+    // CUDA device code
+    return ::fabsf(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::fabsl(x);
+    // HIP/ROCm device code
+    return ::fabsf(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::fabsl(x);
+    // SYCL device code
+    return sycl::fabsf(x);
 #else
-  // standard C++ code
-  return fabsl(x);
+    // standard C++ code
+    return fabsf(x);
 #endif
-}
+  }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double fabs(T x) {
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double fabs(T x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::fabs(x);
+    // CUDA device code
+    return ::fabs(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::fabs(x);
+    // HIP/ROCm device code
+    return ::fabs(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::fabs(x);
+    // SYCL device code
+    return sycl::fabs(x);
 #else
-  // standard C++ code
-  return fabs(x);
+    // standard C++ code
+    return fabs(x);
 #endif
-}
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/abs.h
+++ b/include/math/abs.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -42,23 +42,9 @@ namespace xtd {
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float fabsf(float x) {
-#if defined(XTD_TARGET_CUDA)
-    // CUDA device code
-    return ::fabsf(x);
-#elif defined(XTD_TARGET_HIP)
-    // HIP/ROCm device code
-    return ::fabsf(x);
-#elif defined(XTD_TARGET_SYCL)
-    // SYCL device code
-    return sycl::fabsf(x);
-#else
-    // standard C++ code
-    return fabsf(x);
-#endif
-  }
+  XTD_DEVICE_FUNCTION inline constexpr float fabsf(float x) { return abs(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double fabs(T x) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code

--- a/include/math/acos.h
+++ b/include/math/acos.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float acosf(float arg) { return acos(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double acos(T arg) {
     return acos(static_cast<double>(arg));
   }

--- a/include/math/acos.h
+++ b/include/math/acos.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr float acos(T arg) {
+  inline constexpr float acos(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::acos(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float acosf(float arg) {
-    return acos(arg);
+  inline constexpr double acos(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::acos(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::acos(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::acos(arg);
+#else
+    // standard C++ code
+    return std::acos(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double acosl(long double arg) {
-    return acos(arg);
-  }
+  inline constexpr float acosf(float arg) { return acos(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double acos(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double acos(T arg) {
     return acos(static_cast<double>(arg));
   }
 

--- a/include/math/acosh.h
+++ b/include/math/acosh.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr float acosh(T arg) {
+  inline constexpr float acosh(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::acosh(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float acoshf(float arg) {
-    return acosh(arg);
+  inline constexpr double acosh(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::acosh(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::acosh(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::acosh(arg);
+#else
+    // standard C++ code
+    return std::acosh(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double acoshl(long double arg) {
-    return acosh(arg);
-  }
+  inline constexpr float acoshf(float arg) { return acosh(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double acosh(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double acosh(T arg) {
     return acosh(static_cast<double>(arg));
   }
 

--- a/include/math/acosh.h
+++ b/include/math/acosh.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float acoshf(float arg) { return acosh(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double acosh(T arg) {
     return acosh(static_cast<double>(arg));
   }

--- a/include/math/asin.h
+++ b/include/math/asin.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T asin(T arg) {
+  inline constexpr float asin(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::asin(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float asinf(float arg) {
-    return asin(arg);
+  inline constexpr double asin(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::asin(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::asin(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::asin(arg);
+#else
+    // standard C++ code
+    return std::asin(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double asinl(long double arg) {
-    return asin(arg);
-  }
+  inline constexpr float asinf(float arg) { return asin(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double asinf(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double asinf(T arg) {
     return asin(static_cast<double>(arg));
   }
 

--- a/include/math/asin.h
+++ b/include/math/asin.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float asinf(float arg) { return asin(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double asinf(T arg) {
     return asin(static_cast<double>(arg));
   }

--- a/include/math/asinh.h
+++ b/include/math/asinh.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T asinh(T arg) {
+  inline constexpr float asinh(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::asinh(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float asinhf(float arg) {
-    return asinh(arg);
+  inline constexpr double asinh(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::asinh(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::asinh(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::asinh(arg);
+#else
+    // standard C++ code
+    return std::asinh(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double asinhl(long double arg) {
-    return asinh(arg);
-  }
+  inline constexpr float asinhf(float arg) { return asinh(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double asinhf(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double asinhf(T arg) {
     return asinh(static_cast<double>(arg));
   }
 

--- a/include/math/asinh.h
+++ b/include/math/asinh.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float asinhf(float arg) { return asinh(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double asinhf(T arg) {
     return asinh(static_cast<double>(arg));
   }

--- a/include/math/atan.h
+++ b/include/math/atan.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T atan(T arg) {
+  inline constexpr float atan(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::atan(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float atanf(float arg) {
-    return atan(arg);
+  inline constexpr double atan(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::atan(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::atan(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::atan(arg);
+#else
+    // standard C++ code
+    return std::atan(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double atanl(long double arg) {
-    return atan(arg);
-  }
+  inline constexpr float atanf(float arg) { return atan(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double atan(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double atan(T arg) {
     return atan(static_cast<double>(arg));
   }
 

--- a/include/math/atan.h
+++ b/include/math/atan.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float atanf(float arg) { return atan(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double atan(T arg) {
     return atan(static_cast<double>(arg));
   }

--- a/include/math/atan2.h
+++ b/include/math/atan2.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float atan2f(float x, float y) { return atan2(x, y); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double atan2(T x, T y) {
     return atan2(static_cast<double>(x), static_cast<double>(y));
   }

--- a/include/math/atan2.h
+++ b/include/math/atan2.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T atan2(T x, T y) {
+  inline constexpr float atan2(float x, float y) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::atan2(x, y);
@@ -29,20 +28,28 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float atan2f(float x, float y) {
-    return atan2(x, y);
+  inline constexpr double atan2(double x, double y) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::atan2(x, y);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::atan2(x, y);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::atan2(x, y);
+#else
+    // standard C++ code
+    return std::atan2(x, y);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double atan2l(long double x, long double y) {
-    return atan2(x, y);
-  }
+  inline constexpr float atan2f(float x, float y) { return atan2(x, y); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double atan2(T x, T y) {
+  XTD_DEVICE_FUNCTION inline constexpr double atan2(T x, T y) {
     return atan2(static_cast<double>(x), static_cast<double>(y));
   }
-
 
 }  // namespace xtd

--- a/include/math/atanh.h
+++ b/include/math/atanh.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float atanhf(float arg) { return atanh(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double atanh(T arg) {
     return atanh(static_cast<double>(arg));
   }

--- a/include/math/atanh.h
+++ b/include/math/atanh.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T atanh(T arg) {
+  inline constexpr float atanh(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::atanh(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float atanhf(float arg) {
-    return atanh(arg);
+  inline constexpr double atanh(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::atanh(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::atanh(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::atanh(arg);
+#else
+    // standard C++ code
+    return std::atanh(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double atanhl(long double arg) {
-    return atanh(arg);
-  }
+  inline constexpr float atanhf(float arg) { return atanh(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double atanh(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double atanh(T arg) {
     return atanh(static_cast<double>(arg));
   }
 

--- a/include/math/cbrt.h
+++ b/include/math/cbrt.h
@@ -4,39 +4,49 @@
 #include "internal/defines.h"
 #include <type_traits>
 
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) &&                   \
-    !defined(XTD_TARGET_SYCL)
+#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
 #endif
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T cbrt(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float cbrt(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::cbrt(x);
+    // CUDA device code
+    return ::cbrt(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::cbrt(x);
+    // HIP/ROCm device code
+    return ::cbrt(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::cbrt(x);
+    // SYCL device code
+    return sycl::cbrt(x);
 #else
-  // standard C++ code
-  return std::cbrt(x);
+    // standard C++ code
+    return std::cbrt(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float cbrtf(float x) { return cbrt(x); }
+  XTD_DEVICE_FUNCTION inline constexpr double cbrt(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::cbrt(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::cbrt(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::cbrt(x);
+#else
+    // standard C++ code
+    return std::cbrt(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double cbrtl(long double x) {
-  return cbrt(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float cbrtf(float x) { return cbrt(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double cbrt(T x) {
-  return cbrt(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double cbrt(T x) {
+    return cbrt(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/cbrt.h
+++ b/include/math/cbrt.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float cbrtf(float x) { return cbrt(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double cbrt(T x) {
     return cbrt(static_cast<double>(x));
   }

--- a/include/math/ceil.h
+++ b/include/math/ceil.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T ceil(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float ceil(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::ceil(x);
+    // CUDA device code
+    return ::ceil(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::ceil(x);
+    // HIP/ROCm device code
+    return ::ceil(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::ceil(x);
+    // SYCL device code
+    return sycl::ceil(x);
 #else
-  // standard C++ code
-  return std::ceil(x);
+    // standard C++ code
+    return std::ceil(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float ceilf(float x) {
-  return ceil(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double ceil(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::ceil(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::ceil(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::ceil(x);
+#else
+    // standard C++ code
+    return std::ceil(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double ceill(long double x) {
-  return ceil(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float ceilf(float x) { return ceil(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double ceil(T x) {
-	return ceil(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double ceil(T x) {
+    return ceil(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/ceil.h
+++ b/include/math/ceil.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float ceilf(float x) { return ceil(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double ceil(T x) {
     return ceil(static_cast<double>(x));
   }

--- a/include/math/cos.h
+++ b/include/math/cos.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T cos(T arg) {
+  inline constexpr float cos(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::cos(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float cosf(float arg) {
-    return cos(arg);
+  inline constexpr double cos(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::cos(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::cos(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::cos(arg);
+#else
+    // standard C++ code
+    return std::cos(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double cosl(long double arg) {
-    return cos(arg);
-  }
+  inline constexpr float cosf(float arg) { return cos(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double cos(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double cos(T arg) {
     return cos(static_cast<double>(arg));
   }
 

--- a/include/math/cos.h
+++ b/include/math/cos.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float cosf(float arg) { return cos(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double cos(T arg) {
     return cos(static_cast<double>(arg));
   }

--- a/include/math/cosh.h
+++ b/include/math/cosh.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T cosh(T arg) {
+  inline constexpr float cosh(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::cosh(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float coshf(float arg) {
-    return cosh(arg);
+  inline constexpr double cosh(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::cosh(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::cosh(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::cosh(arg);
+#else
+    // standard C++ code
+    return std::cosh(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double coshl(long double arg) {
-    return cosh(arg);
-  }
+  inline constexpr float coshf(float arg) { return cosh(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double cosh(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double cosh(T arg) {
     return cosh(static_cast<double>(arg));
   }
 

--- a/include/math/cosh.h
+++ b/include/math/cosh.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float coshf(float arg) { return cosh(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double cosh(T arg) {
     return cosh(static_cast<double>(arg));
   }

--- a/include/math/exp.h
+++ b/include/math/exp.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float expf(float x) { return exp(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double exp(T x) {
     return exp(static_cast<double>(x));
   }

--- a/include/math/exp.h
+++ b/include/math/exp.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T exp(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float exp(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::exp(x);
+    // CUDA device code
+    return ::exp(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::exp(x);
+    // HIP/ROCm device code
+    return ::exp(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::exp(x);
+    // SYCL device code
+    return sycl::exp(x);
 #else
-  // standard C++ code
-  return std::exp(x);
+    // standard C++ code
+    return std::exp(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float expf(float x) {
-  return exp(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double exp(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::exp(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::exp(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::exp(x);
+#else
+    // standard C++ code
+    return std::exp(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double expl(long double x) {
-  return exp(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float expf(float x) { return exp(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double exp(T x) {
-	return exp(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double exp(T x) {
+    return exp(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/exp2.h
+++ b/include/math/exp2.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float exp2f(float x) { return exp2(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double exp2(T x) {
     return exp2(static_cast<double>(x));
   }

--- a/include/math/exp2.h
+++ b/include/math/exp2.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T exp2(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float exp2(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::exp2(x);
+    // CUDA device code
+    return ::exp2(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::exp2(x);
+    // HIP/ROCm device code
+    return ::exp2(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::exp2(x);
+    // SYCL device code
+    return sycl::exp2(x);
 #else
-  // standard C++ code
-  return std::exp2(x);
+    // standard C++ code
+    return std::exp2(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float exp2f(float x) {
-  return exp2(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double exp2(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::exp2(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::exp2(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::exp2(x);
+#else
+    // standard C++ code
+    return std::exp2(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double exp2l(long double x) {
-  return exp2(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float exp2f(float x) { return exp2(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double exp2(T x) {
-	return exp2(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double exp2(T x) {
+    return exp2(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/expm1.h
+++ b/include/math/expm1.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T expm1(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float expm1(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::expm1(x);
+    // CUDA device code
+    return ::expm1(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::expm1(x);
+    // HIP/ROCm device code
+    return ::expm1(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::expm1(x);
+    // SYCL device code
+    return sycl::expm1(x);
 #else
-  // standard C++ code
-  return std::expm1(x);
+    // standard C++ code
+    return std::expm1(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float expm1f(float x) {
-  return expm1(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double expm1(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::expm1(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::expm1(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::expm1(x);
+#else
+    // standard C++ code
+    return std::expm1(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double expm1l(long double x) {
-  return expm1(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float expm1f(float x) { return expm1(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double expm1(T x) {
-	return expm1(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double expm1(T x) {
+    return expm1(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/expm1.h
+++ b/include/math/expm1.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float expm1f(float x) { return expm1(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double expm1(T x) {
     return expm1(static_cast<double>(x));
   }

--- a/include/math/floor.h
+++ b/include/math/floor.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float floorf(float x) { return floor(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double floor(T x) {
     return floor(static_cast<double>(x));
   }

--- a/include/math/floor.h
+++ b/include/math/floor.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T floor(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float floor(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::floor(x);
+    // CUDA device code
+    return ::floor(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::floor(x);
+    // HIP/ROCm device code
+    return ::floor(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::floor(x);
+    // SYCL device code
+    return sycl::floor(x);
 #else
-  // standard C++ code
-  return std::floor(x);
+    // standard C++ code
+    return std::floor(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float floorf(float x) {
-  return floor(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double floor(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::floor(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::floor(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::floor(x);
+#else
+    // standard C++ code
+    return std::floor(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double floorl(long double x) {
-  return floor(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float floorf(float x) { return floor(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double floor(T x) {
-	return floor(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double floor(T x) {
+    return floor(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/hypot.h
+++ b/include/math/hypot.h
@@ -10,29 +10,38 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T hypot(T x, T y) {
+  XTD_DEVICE_FUNCTION inline constexpr float hypot(float x, float y) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::hypot(x, y);
+    // CUDA device code
+    return ::hypot(x, y);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::hypot(x, y);
+    // HIP/ROCm device code
+    return ::hypot(x, y);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::hypot(x, y);
+    // SYCL device code
+    return sycl::hypot(x, y);
 #else
-  // standard C++ code
-  return std::hypot(x, y);
+    // standard C++ code
+    return std::hypot(x, y);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float hypotf(float x, float y) {
-  return hypot(x, y);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double hypot(double x, double y) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::hypot(x, y);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::hypot(x, y);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::hypot(x, y);
+#else
+    // standard C++ code
+    return std::hypot(x, y);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double hypotl(long double x, long double y) {
-  return hypot(x, y);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float hypotf(float x, float y) { return hypot(x, y); }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/hypot.h
+++ b/include/math/hypot.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>

--- a/include/math/log.h
+++ b/include/math/log.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float logf(float x) { return log(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double log(T x) {
     return log(static_cast<double>(x));
   }

--- a/include/math/log.h
+++ b/include/math/log.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T log(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float log(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::log(x);
+    // CUDA device code
+    return ::log(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::log(x);
+    // HIP/ROCm device code
+    return ::log(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::log(x);
+    // SYCL device code
+    return sycl::log(x);
 #else
-  // standard C++ code
-  return std::log(x);
+    // standard C++ code
+    return std::log(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float logf(float x) {
-  return log(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double log(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::log(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::log(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::log(x);
+#else
+    // standard C++ code
+    return std::log(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double logl(long double x) {
-  return log(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float logf(float x) { return log(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double log(T x) {
-	return log(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double log(T x) {
+    return log(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/log10.h
+++ b/include/math/log10.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T log10(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float log10(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::log10(x);
+    // CUDA device code
+    return ::log10(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::log10(x);
+    // HIP/ROCm device code
+    return ::log10(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::log10(x);
+    // SYCL device code
+    return sycl::log10(x);
 #else
-  // standard C++ code
-  return std::log10(x);
+    // standard C++ code
+    return std::log10(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float log10f(float x) {
-  return log10(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double log10(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::log10(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::log10(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::log10(x);
+#else
+    // standard C++ code
+    return std::log10(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double log10l(long double x) {
-  return log10(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float log10f(float x) { return log10(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double log10(T x) {
-	return log10(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double log10(T x) {
+    return log10(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/log10.h
+++ b/include/math/log10.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float log10f(float x) { return log10(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double log10(T x) {
     return log10(static_cast<double>(x));
   }

--- a/include/math/log1p.h
+++ b/include/math/log1p.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float log1pf(float x) { return std::log1p(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double log1p(T x) {
     return log1p(static_cast<double>(x));
   }

--- a/include/math/log1p.h
+++ b/include/math/log1p.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T log1p(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float log1p(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::log1p(x);
+    // CUDA device code
+    return ::log1p(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::log1p(x);
+    // HIP/ROCm device code
+    return ::log1p(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::log1p(x);
+    // SYCL device code
+    return sycl::log1p(x);
 #else
-  // standard C++ code
-  return std::log1p(x);
+    // standard C++ code
+    return std::log1p(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float log1pf(float x) {
-  return std::log1p(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double log1p(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::log1p(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::log1p(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::log1p(x);
+#else
+    // standard C++ code
+    return std::log1p(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double log1pl(long double x) {
-  return std::log1p(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float log1pf(float x) { return std::log1p(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double log1p(T x) {
-	return log1p(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double log1p(T x) {
+    return log1p(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/log2.h
+++ b/include/math/log2.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T log2(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float log2(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::log2(x);
+    // CUDA device code
+    return ::log2(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::log2(x);
+    // HIP/ROCm device code
+    return ::log2(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::log2(x);
+    // SYCL device code
+    return sycl::log2(x);
 #else
-  // standard C++ code
-  return std::log2(x);
+    // standard C++ code
+    return std::log2(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float log2f(float x) {
-  return log2(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double log2(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::log2(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::log2(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::log2(x);
+#else
+    // standard C++ code
+    return std::log2(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double log2l(long double x) {
-  return log2(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float log2f(float x) { return log2(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double log2(T x) {
-	return log2(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double log2(T x) {
+    return log2(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/log2.h
+++ b/include/math/log2.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float log2f(float x) { return log2(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double log2(T x) {
     return log2(static_cast<double>(x));
   }

--- a/include/math/max.h
+++ b/include/math/max.h
@@ -6,11 +6,12 @@
 #endif
 
 #include "internal/defines.h"
+#include "internal/concepts.h"
 #include <type_traits>
 
 namespace xtd {
 
-  template <typename T>
+  template <Numeric T>
   XTD_DEVICE_FUNCTION inline constexpr const T& max(const T& a, const T& b) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
@@ -27,7 +28,7 @@ namespace xtd {
 #endif
   }
 
-  template <typename T, typename Compare>
+  template <Numeric T, typename Compare>
   XTD_DEVICE_FUNCTION inline constexpr const T& max(const T& a, const T& b, Compare comp) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code

--- a/include/math/max.h
+++ b/include/math/max.h
@@ -10,37 +10,38 @@
 
 namespace xtd {
 
-template <typename T> XTD_DEVICE_FUNCTION inline constexpr const T& max(const T& a, const T& b) {
+  template <typename T>
+  XTD_DEVICE_FUNCTION inline constexpr const T& max(const T& a, const T& b) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::max(a, b);
+    // CUDA device code
+    return ::max(a, b);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::max(a, b);
+    // HIP/ROCm device code
+    return ::max(a, b);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::max(a, b);
+    // SYCL device code
+    return sycl::max(a, b);
 #else
-  // standard C++ code
-  return std::max(a, b);
+    // standard C++ code
+    return std::max(a, b);
 #endif
-}
+  }
 
-template <typename T, typename Compare>
-XTD_DEVICE_FUNCTION inline constexpr const T& max(const T& a, const T& b, Compare comp) {
+  template <typename T, typename Compare>
+  XTD_DEVICE_FUNCTION inline constexpr const T& max(const T& a, const T& b, Compare comp) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::max(a, b, comp);
+    // CUDA device code
+    return ::max(a, b, comp);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::max(a, b, comp);
+    // HIP/ROCm device code
+    return ::max(a, b, comp);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::max(a, b, comp);
+    // SYCL device code
+    return sycl::max(a, b, comp);
 #else
-  // standard C++ code
-  return std::max(a, b, comp);
+    // standard C++ code
+    return std::max(a, b, comp);
 #endif
-}
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/min.h
+++ b/include/math/min.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
+#include "internal/concepts.h"
 #include <type_traits>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
@@ -10,7 +11,7 @@
 
 namespace xtd {
 
-  template <typename T>
+  template <Numeric T>
   XTD_DEVICE_FUNCTION inline constexpr const T& min(const T& a, const T& b) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
@@ -27,7 +28,7 @@ namespace xtd {
 #endif
   }
 
-  template <typename T, typename Compare>
+  template <Numeric T, typename Compare>
   XTD_DEVICE_FUNCTION inline constexpr const T& min(const T& a, const T& b, Compare comp) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code

--- a/include/math/min.h
+++ b/include/math/min.h
@@ -10,37 +10,38 @@
 
 namespace xtd {
 
-template <typename T> XTD_DEVICE_FUNCTION inline constexpr const T& min(const T& a, const T& b) {
+  template <typename T>
+  XTD_DEVICE_FUNCTION inline constexpr const T& min(const T& a, const T& b) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::min(a, b);
+    // CUDA device code
+    return ::min(a, b);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::min(a, b);
+    // HIP/ROCm device code
+    return ::min(a, b);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::min(a, b);
+    // SYCL device code
+    return sycl::min(a, b);
 #else
-  // standard C++ code
-  return std::min(a, b);
+    // standard C++ code
+    return std::min(a, b);
 #endif
-}
+  }
 
-template <typename T, typename Compare>
-XTD_DEVICE_FUNCTION inline constexpr const T& min(const T& a, const T& b, Compare comp) {
+  template <typename T, typename Compare>
+  XTD_DEVICE_FUNCTION inline constexpr const T& min(const T& a, const T& b, Compare comp) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::min(a, b, comp);
+    // CUDA device code
+    return ::min(a, b, comp);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::min(a, b, comp);
+    // HIP/ROCm device code
+    return ::min(a, b, comp);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::min(a, b, comp);
+    // SYCL device code
+    return sycl::min(a, b, comp);
 #else
-  // standard C++ code
-  return std::min(a, b, comp);
+    // standard C++ code
+    return std::min(a, b, comp);
 #endif
-}
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/mod.h
+++ b/include/math/mod.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -42,9 +42,9 @@ namespace xtd {
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float fmodf(float x, float y) { return fmodf(x, y); }
+  XTD_DEVICE_FUNCTION inline constexpr float fmodf(float x, float y) { return fmod(x, y); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double fmod(T x, T y) {
     return fmod(static_cast<double>(x), static_cast<double>(y));
   }

--- a/include/math/mod.h
+++ b/include/math/mod.h
@@ -10,34 +10,43 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T fmod(T x, T y) {
+  XTD_DEVICE_FUNCTION inline constexpr float fmod(float x, float y) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::fmod(x, y);
+    // CUDA device code
+    return ::fmod(x, y);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::fmod(x, y);
+    // HIP/ROCm device code
+    return ::fmod(x, y);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::fmod(x, y);
+    // SYCL device code
+    return sycl::fmod(x, y);
 #else
-  // standard C++ code
-  return std::fmod(x, y);
+    // standard C++ code
+    return std::fmod(x, y);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float fmodf(float x, float y) {
-  return fmodf(x, y);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double fmod(double x, double y) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::fmod(x, y);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::fmod(x, y);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::fmod(x, y);
+#else
+    // standard C++ code
+    return std::fmod(x, y);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double fmodl(long double x, long double y) {
-  return fmodl(x, y);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float fmodf(float x, float y) { return fmodf(x, y); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double fmod(T x, T y) {
-  return fmod(static_cast<double>(x), static_cast<double>(y));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double fmod(T x, T y) {
+    return fmod(static_cast<double>(x), static_cast<double>(y));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/pow.h
+++ b/include/math/pow.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -42,6 +41,6 @@ namespace xtd {
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float powf(float base, float exp) { return powf(base, exp); }
+  XTD_DEVICE_FUNCTION inline constexpr float powf(float base, float exp) { return pow(base, exp); }
 
 }  // namespace xtd

--- a/include/math/pow.h
+++ b/include/math/pow.h
@@ -10,29 +10,38 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T pow(T base, T exp) {
+  XTD_DEVICE_FUNCTION inline constexpr float pow(float base, float exp) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::pow(base, exp);
+    // CUDA device code
+    return ::pow(base, exp);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::pow(base, exp);
+    // HIP/ROCm device code
+    return ::pow(base, exp);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::pow(base, exp);
+    // SYCL device code
+    return sycl::pow(base, exp);
 #else
-  // standard C++ code
-  return std::pow(base, exp);
+    // standard C++ code
+    return std::pow(base, exp);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float powf(float base, float exp) {
-  return powf(base, exp);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double pow(double base, double exp) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::pow(base, exp);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::pow(base, exp);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::pow(base, exp);
+#else
+    // standard C++ code
+    return std::pow(base, exp);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double powl(long double base, long double exp) {
-  return powl(base, exp);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float powf(float base, float exp) { return powf(base, exp); }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/remainder.h
+++ b/include/math/remainder.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -46,7 +46,7 @@ namespace xtd {
     return remainder(x, y);
   }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double remainder(T x, T y) {
     return remainder(static_cast<double>(x), static_cast<double>(y));
   }

--- a/include/math/remainder.h
+++ b/include/math/remainder.h
@@ -10,34 +10,45 @@
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T remainder(T x, T y) {
+  XTD_DEVICE_FUNCTION inline constexpr float remainder(float x, float y) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::remainder(x, y);
+    // CUDA device code
+    return ::remainder(x, y);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::remainder(x, y);
+    // HIP/ROCm device code
+    return ::remainder(x, y);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::remainder(x, y);
+    // SYCL device code
+    return sycl::remainder(x, y);
 #else
-  // standard C++ code
-  return std::remainder(x, y);
+    // standard C++ code
+    return std::remainder(x, y);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float remainderf(float x, float y) {
-  return remainder(x, y);
-}
+  XTD_DEVICE_FUNCTION inline constexpr double remainder(double x, double y) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::remainder(x, y);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::remainder(x, y);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::remainder(x, y);
+#else
+    // standard C++ code
+    return std::remainder(x, y);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double remainderl(long double x, long double y) {
-  return remainder(x, y);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float remainderf(float x, float y) {
+    return remainder(x, y);
+  }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double remainder(T x, T y) {
-  return remainder(static_cast<double>(x), static_cast<double>(y));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double remainder(T x, T y) {
+    return remainder(static_cast<double>(x), static_cast<double>(y));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/sin.h
+++ b/include/math/sin.h
@@ -6,11 +6,8 @@
 
 #pragma once
 
-#include <cmath>
-#include <type_traits>
-
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -59,7 +56,7 @@ namespace xtd {
   /* Computes the sine of arg (measured in radians),
    * in double precision.
    */
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double sin(T arg) {
     return sin(static_cast<double>(arg));
   }
@@ -72,7 +69,7 @@ namespace xtd {
   /* Computes the sine of arg (measured in radians),
    * in single precision.
    */
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double sinf(T arg) {
     return sin(static_cast<float>(arg));
   }

--- a/include/math/sinh.h
+++ b/include/math/sinh.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -46,7 +46,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float sinhf(float arg) { return sinh(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double sinh(T arg) {
     return sinh(static_cast<double>(arg));
   }

--- a/include/math/sinh.h
+++ b/include/math/sinh.h
@@ -9,9 +9,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T sinh(T arg) {
+  inline constexpr float sinh(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::sinh(arg);
@@ -45,18 +44,10 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float sinhf(float arg) {
-    return sinh(arg);
-  }
-
-  XTD_DEVICE_FUNCTION
-  inline constexpr long double sinhl(long double arg) {
-    return sinh(arg);
-  }
+  inline constexpr float sinhf(float arg) { return sinh(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double sinh(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double sinh(T arg) {
     return sinh(static_cast<double>(arg));
   }
 

--- a/include/math/sqrt.h
+++ b/include/math/sqrt.h
@@ -4,39 +4,49 @@
 #include "internal/defines.h"
 #include <type_traits>
 
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) &&                   \
-    !defined(XTD_TARGET_SYCL)
+#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
 #endif
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T sqrt(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float sqrt(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::sqrt(x);
+    // CUDA device code
+    return ::sqrt(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::sqrt(x);
+    // HIP/ROCm device code
+    return ::sqrt(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::sqrt(x);
+    // SYCL device code
+    return sycl::sqrt(x);
 #else
-  // standard C++ code
-  return std::sqrt(x);
+    // standard C++ code
+    return std::sqrt(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float sqrtf(float x) { return sqrt(x); }
+  XTD_DEVICE_FUNCTION inline constexpr double sqrt(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::sqrt(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::sqrt(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::sqrt(x);
+#else
+    // standard C++ code
+    return std::sqrt(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double sqrtl(long double x) {
-  return sqrt(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float sqrtf(float x) { return sqrt(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double sqrt(T x) {
-  return sqrt(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double sqrt(T x) {
+    return sqrt(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/include/math/sqrt.h
+++ b/include/math/sqrt.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float sqrtf(float x) { return sqrt(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double sqrt(T x) {
     return sqrt(static_cast<double>(x));
   }

--- a/include/math/tan.h
+++ b/include/math/tan.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float tanf(float arg) { return tan(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double tan(T arg) {
     return tan(static_cast<double>(arg));
   }

--- a/include/math/tan.h
+++ b/include/math/tan.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T tan(T arg) {
+  inline constexpr float tan(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::tan(arg);
@@ -29,18 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float tanf(float arg) {
-    return tan(arg);
+  inline constexpr double tan(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::tan(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::tan(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::tan(arg);
+#else
+    // standard C++ code
+    return std::tan(arg);
+#endif
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr long double tanl(long double arg) {
-    return tan(arg);
-  }
+  inline constexpr float tanf(float arg) { return tan(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double tan(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double tan(T arg) {
     return tan(static_cast<double>(arg));
   }
 

--- a/include/math/tanh.h
+++ b/include/math/tanh.h
@@ -10,9 +10,8 @@
 
 namespace xtd {
 
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr T tanh(T arg) {
+  inline constexpr float tanh(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::tanh(arg);
@@ -29,19 +28,27 @@ namespace xtd {
   }
 
   XTD_DEVICE_FUNCTION
-  inline constexpr float tanhf(float arg) {
-    return tanh(arg);
+  inline constexpr double tanh(double arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::tanh(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::tanh(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::tanh(arg);
+#else
+    // stanhdard C++ code
+    return std::tanh(arg);
+#endif
   }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
   XTD_DEVICE_FUNCTION
-  inline constexpr long double tanhl(long double arg) {
-    return tanh(arg);
-  }
+  inline constexpr float tanhf(float arg) { return tanh(arg); }
 
   template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-  XTD_DEVICE_FUNCTION
-  inline constexpr double tanh(T arg) {
+  XTD_DEVICE_FUNCTION inline constexpr double tanh(T arg) {
     return tanh(static_cast<double>(arg));
   }
 

--- a/include/math/tanh.h
+++ b/include/math/tanh.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -47,7 +47,7 @@ namespace xtd {
   XTD_DEVICE_FUNCTION
   inline constexpr float tanhf(float arg) { return tanh(arg); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double tanh(T arg) {
     return tanh(static_cast<double>(arg));
   }

--- a/include/math/trunc.h
+++ b/include/math/trunc.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "internal/defines.h"
-#include <type_traits>
+#include <concepts>
 
 #if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
@@ -44,7 +44,7 @@ namespace xtd {
 
   XTD_DEVICE_FUNCTION inline constexpr float truncf(float x) { return trunc(x); }
 
-  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  template <std::integral T>
   XTD_DEVICE_FUNCTION inline constexpr double trunc(T x) {
     return trunc(static_cast<double>(x));
   }

--- a/include/math/trunc.h
+++ b/include/math/trunc.h
@@ -4,39 +4,49 @@
 #include "internal/defines.h"
 #include <type_traits>
 
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) &&                   \
-    !defined(XTD_TARGET_SYCL)
+#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
 #endif
 
 namespace xtd {
 
-template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr T trunc(T x) {
+  XTD_DEVICE_FUNCTION inline constexpr float trunc(float x) {
 #if defined(XTD_TARGET_CUDA)
-  // CUDA device code
-  return ::trunc(x);
+    // CUDA device code
+    return ::trunc(x);
 #elif defined(XTD_TARGET_HIP)
-  // HIP/ROCm device code
-  return ::trunc(x);
+    // HIP/ROCm device code
+    return ::trunc(x);
 #elif defined(XTD_TARGET_SYCL)
-  // SYCL device code
-  return sycl::trunc(x);
+    // SYCL device code
+    return sycl::trunc(x);
 #else
-  // standard C++ code
-  return std::trunc(x);
+    // standard C++ code
+    return std::trunc(x);
 #endif
-}
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr float truncf(float x) { return trunc(x); }
+  XTD_DEVICE_FUNCTION inline constexpr double trunc(double x) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::trunc(x);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::trunc(x);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::trunc(x);
+#else
+    // standard C++ code
+    return std::trunc(x);
+#endif
+  }
 
-XTD_DEVICE_FUNCTION inline constexpr long double truncl(long double x) {
-  return trunc(x);
-}
+  XTD_DEVICE_FUNCTION inline constexpr float truncf(float x) { return trunc(x); }
 
-template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-XTD_DEVICE_FUNCTION inline constexpr double trunc(T x) {
-  return trunc(static_cast<double>(x));
-}
+  template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+  XTD_DEVICE_FUNCTION inline constexpr double trunc(T x) {
+    return trunc(static_cast<double>(x));
+  }
 
-} // namespace xtd
+}  // namespace xtd

--- a/test/Makefile
+++ b/test/Makefile
@@ -12,7 +12,7 @@ HOST_CXXFLAGS := -O2 -fPIC -pthread -march=native -Wall -Wextra -Werror -Wfatal-
 # Compiler flags supported by GCC but not by the LLVM-based compilers (clang, hipcc, icpx, etc.)
 LLVM_UNSUPPORTED_CXXFLAGS := --param vect-max-version-for-alias-checks=50 -Werror=format-contains-nul -Wno-non-template-friend -Werror=return-local-addr -Werror=unused-but-set-variable
 
-CXXFLAGS := -std=c++17 $(HOST_CXXFLAGS) -g
+CXXFLAGS := -std=c++20 $(HOST_CXXFLAGS) -g
 LDFLAGS := -O2 -fPIC -pthread -Wl,-E -lstdc++fs -ldl
 
 # CUDA
@@ -31,11 +31,11 @@ else
   CUDA_NVCC := $(CUDA_BASE)/bin/nvcc
   define CUFLAGS_template
     $(2)NVCC_FLAGS := $$(foreach ARCH,$(1),-gencode arch=compute_$$(ARCH),code=[sm_$$(ARCH),compute_$$(ARCH)]) -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --expt-relaxed-constexpr --expt-extended-lambda --generate-line-info --source-in-ptx --display-error-number --threads $$(words $(1)) --cudart=shared
-    $(2)NVCC_COMMON := -std=c++17 -O3 -g $$($(2)NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS)'
+    $(2)NVCC_COMMON := -std=c++20 -O3 -g $$($(2)NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS)'
     $(2)CUDA_CUFLAGS := $$($(2)NVCC_COMMON)
   endef
   $(eval $(call CUFLAGS_template,$(CUDA_ARCH),))
-  NVCC_COMMON := -std=c++17 -O3 -g $(NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS)'
+  NVCC_COMMON := -std=c++20 -O3 -g $(NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS)'
   CUDA_CUFLAGS := $(NVCC_COMMON)
 endif
 


### PR DESCRIPTION
Since CUDA doesn't support `long double`, this PR remove the interface for those overloads, and explicitly overloads for `float` and `double`.
Also starts using concepts instead of type traits for better clarity.