### PR TITLE
Test with nominal accuracy against GNU MPFR reference

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,10 +7,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install dependencies
+      run: |
+        sudo apt install -y libmpfr-dev
+
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Build and Run Tests
+    - name: Build and run tests
       working-directory: test
       run: |
         make all

--- a/README.md
+++ b/README.md
@@ -1,2 +1,222 @@
 # xtd
-C++ functions for CPU and GPUs with a consistent interface
+
+C++ functions for CPU and GPUs with a consistent interface.
+
+
+## Accuracy of mathematical functions
+
+For a detailed comparison of the accuracy of different math library
+implementations, see
+
+  “Accuracy of Mathematical Functions in Single, Double, Double Extended, and
+  Quadruple Precision”, Brian Gladman, Vincenzo Innocente, John Mather, Paul
+  Zimmermann, hal-03141101v8, https://inria.hal.science/hal-03141101 .
+
+
+### GNU libc
+
+On a Linux system the math functions are usually provided by GNU libc.
+The accuracy of the GNU libc math functions implementation is described in
+https://www.gnu.org/software/libc/manual/html_node/Errors-in-Math-Functions.html
+and summarised below for an x86_64 host system:
+
+function         |  float | double
+-----------------|--------|--------
+acosf / acos     |      1 |      1
+acoshf / acosh   |      2 |      2
+asinf / asin     |      1 |      1
+asinhf / asinh   |      2 |      2
+atan2f / atan2   |      2 |      0
+atanf / atan     |      1 |      1
+atanhf / atanh   |      2 |      2
+cbrtf / cbrt     |      1 |      4
+cosf / cos       |      1 |      1
+coshf / cosh     |      2 |      2
+erfcf / erfc     |      3 |      5
+erff / erf       |      1 |      1
+exp10f / exp10   |      1 |      2
+exp2f / exp2     |      1 |      1
+expf / exp       |      1 |      1
+expm1f / expm1   |      1 |      1
+fmaf / fma       |      0 |      0
+fmodf / fmod     |      0 |      0
+hypotf / hypot   |      1 |      1
+j0f / j0         |      9 |      3
+j1f / j1         |      9 |      4
+jnf / jn         |      4 |      4
+lgammaf / lgamma |      7 |      4
+log10f / log10   |      2 |      2
+log1pf / log1p   |      1 |      1
+log2f / log2     |      1 |      2
+logf / log       |      1 |      1
+pow10f / pow10   |      0 |      0
+powf / pow       |      1 |      1
+sincosf / sincos |      0 |      1
+sinf / sin       |      1 |      1
+sinhf / sinh     |      2 |      2
+sqrtf / sqrt     |      0 |      0
+tanf / tan       |      1 |      0
+tanhf / tanh     |      2 |      2
+tgammaf / tgamma |      8 |      9
+y0f / y0         |      9 |      3
+y1f / y1         |      9 |      6
+ynf / yn         |      3 |      3
+
+
+### NVIDIA CUDA
+
+The accuracy of the NVIDIA CUDA math functions implementation is described in
+https://docs.nvidia.com/cuda/cuda-c-programming-guide/#standard-functions
+and summarised below for GPUs with compute capability 5.2 or higher:
+
+function         |      float |     double
+-----------------|------------|------------
+acosf / acos     |         2  |          2
+acoshf / acosh   |         4  |          3
+asinf / asin     |         2  |          2
+asinhf / asinh   |         3  |          3
+atan2f / atan2   |         3  |          2
+atanf / atan     |         2  |          2
+atanhf / atanh   |         3  |          2
+cbrtf / cbrt     |         1  |          1
+cosf / cos       |         2† |          2
+coshf / cosh     |         2  |          1
+erfcf / erfc     |         4  |          5
+erff / erf       |         2  |          2
+exp10f / exp10   |         2† |          1
+exp2f / exp2     |         2  |          1
+expf / exp       |         2† |          1
+expm1f / expm1   |         1  |          1
+fmaf / fma       |         0  |          0
+fmodf / fmod     |         0  |          0
+hypotf / hypot   |         3  |          2
+j0f / j0         |         9* |          7ᕯ
+j1f / j1         |         9* |          7ᕯ
+jnf / jn         | 2 + 2.5×n* |        n/aᕯ
+lgammaf / lgamma |         6' |          4"
+log10f / log10   |         2† |          1
+log1pf / log1p   |         1  |          1
+log2f / log2     |         1† |          1
+logf / log       |         1† |          1
+pow10f / pow10   |       n/a  |        n/a
+powf / pow       |         4† |          2
+sincosf / sincos |         2† |          2
+sinf / sin       |         2† |          2
+sinhf / sinh     |         3  |          2
+sqrtf / sqrt     |         0‡ |          0
+tanf / tan       |         4† |          2
+tanhf / tanh     |         2† |          1
+tgammaf / tgamma |         5  |         10
+y0f / y0         |         9* |          7ᕯ
+y1f / y1         |         9* |          7ᕯ
+ynf / yn         | 2 + 2.5×n* |        n/a
+
+  - † unless compiled with `--use_fast_math`
+  - ‡ unless compiled with `--use_fast_math` or `--prec-sqrt=false`
+  - * for |x| < 8, otherwise, the maximum absolute error is 2.2×10⁻⁶
+  - ᕯ for |x| < 8, otherwise, the maximum absolute error is 5×10⁻¹²
+  - ' outside interval -10.001 … -2.264; larger inside
+  - " outside interval -23.0001 … -2.2637; larger inside
+
+
+### AMD HIP/ROCm
+
+The accuracy of the AMD ROCm math functions implementation is described in
+https://rocm.docs.amd.com/projects/HIP/en/latest/reference/math_api.html
+and summarised below:
+
+function         |  float | double
+-----------------|--------|--------
+acosf / acos     |      1 |      1
+acoshf / acosh   |      1 |      1
+asinf / asin     |      2 |      1
+asinhf / asinh   |      1 |      1
+atan2f / atan2   |      1 |      1
+atanf / atan     |      2 |      1
+atanhf / atanh   |      1 |      1
+cbrtf / cbrt     |      2 |      1
+cosf / cos       |      1 |      1
+coshf / cosh     |      1 |      1
+erfcf / erfc     |      2 |      2
+erff / erf       |      4 |      4
+exp10f / exp10   |      1 |      1
+exp2f / exp2     |      1 |      1
+expf / exp       |      1 |      1
+expm1f / expm1   |      1 |      1
+fmaf / fma       |      0 |      0
+fmodf / fmod     |      0 |      0
+hypotf / hypot   |      1 |      1
+j0f / j0         |    n/a |    n/a
+j1f / j1         |    n/a |    n/a
+jnf / jn         |    n/a |    n/a
+lgammaf / lgamma |      4 |      2
+log10f / log10   |      2 |      1
+log1pf / log1p   |      1 |      1
+log2f / log2     |      1 |      1
+logf / log       |      2 |      1
+pow10f / pow10   |    n/a |    n/a
+powf / pow       |      1 |      1
+sincosf / sincos |      1 |      1
+sinf / sin       |      1 |      1
+sinhf / sinh     |      1 |      1
+sqrtf / sqrt     |      1 |      1
+tanf / tan       |      1 |      1
+tanhf / tanh     |      2 |      1
+tgammaf / tgamma |      6 |      6
+y0f / y0         |    n/a |    n/a
+y1f / y1         |    n/a |    n/a
+ynf / yn         |    n/a |    n/a
+
+Note: in some cases the accuracy is documented only for a small range of values.
+
+
+### Intel oneAPI
+
+The accuracy of the Intel oneAPI math functions implementation is described in
+https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2025-2/imf-transcendental-math-functions.html
+and summarised below for the default accuracy:
+
+function         |   float |  double
+-----------------|---------|---------
+acosf / acos     |      3  |      1
+acoshf / acosh   |      2  |      2
+asinf / asin     |      4  |      1
+asinhf / asinh   |      2  |      2
+atan2f / atan2   |      3  |      1
+atanf / atan     |      1  |      1
+atanhf / atanh   |      2  |      3
+cbrtf / cbrt     |      1  |      1
+cosf / cos       |      2  |      1
+coshf / cosh     |      2  |      1
+erfcf / erfc     |      3  |      3
+erff / erf       |      1  |      1
+exp10f / exp10   |      1  |      1
+exp2f / exp2     |      1  |      1
+expf / exp       |      1  |      1
+expm1f / expm1   |      1  |      1
+fmaf / fma       |      0  |      0
+fmodf / fmod     |      0  |      0
+hypotf / hypot   |      1  |      2
+j0f / j0         |      3  |      4
+j1f / j1         |      3  |      4
+jnf / jn         |     80  |   2700
+lgammaf / lgamma |      3  |      4
+log10f / log10   |      2  |      1
+log1pf / log1p   |      1  |      1
+log2f / log2     |      1  |      1
+logf / log       |      1  |      1
+pow10f / pow10   |    n/a  |    n/a
+powf / pow       |      2  |      1
+sincosf / sincos |      3  |      2
+sinf / sin       |      2  |      1
+sinhf / sinh     |      2  |      2
+sqrtf / sqrt     |      3† |      0†
+tanf / tan       |      4  |      1
+tanhf / tanh     |      1  |      1
+tgammaf / tgamma |      3  |      9
+y0f / y0         |      4  |      6
+y1f / y1         |      5  |      4
+ynf / yn         |    145  |   2000
+
+  - † according to the OpenCL standard; may be affected by the `-ffast-math` compiler option.
+

--- a/include/xtd/internal/defines.h
+++ b/include/xtd/internal/defines.h
@@ -30,6 +30,15 @@
 #define XTD_TARGET_CPU
 #endif
 
-#if defined(__SYCL_DEVICE_ONLY__)
+// backend runtime include files
+#if defined(XTD_TARGET_CUDA)
+#include <cuda_runtime.h>
+#endif
+
+#if defined(XTD_TARGET_HIP)
+#include <hip/hip_runtime.h>
+#endif
+
+#if defined(XTD_TARGET_SYCL)
 #include <sycl/sycl.hpp>
 #endif

--- a/include/xtd/math/sin.h
+++ b/include/xtd/math/sin.h
@@ -26,8 +26,8 @@ namespace xtd {
     // SYCL device code
     return sycl::sin(arg);
 #else
-    // standard C++ code
-    return std::sin(arg);
+    // standard C/C++ code
+    return ::sinf(arg);
 #endif
   }
 
@@ -44,20 +44,24 @@ namespace xtd {
     // SYCL device code
     return sycl::sin(arg);
 #else
-    // standard C++ code
-    return std::sin(arg);
+    // standard C/C++ code
+    return ::sin(arg);
 #endif
   }
 
   /* Computes the sine of arg (measured in radians), in double precision.
    */
   XTD_DEVICE_FUNCTION inline constexpr double sin(std::integral auto arg) {
-    return sin(static_cast<double>(arg));
+    return xtd::sin(static_cast<double>(arg));
   }
 
   /* Computes the sine of arg (measured in radians), in single precision.
    */
-  XTD_DEVICE_FUNCTION inline constexpr float sinf(std::floating_point auto arg) { return xtd::sin(static_cast<float>(arg)); }
-  XTD_DEVICE_FUNCTION inline constexpr float sinf(std::integral auto arg) { return xtd::sin(static_cast<float>(arg)); }
+  XTD_DEVICE_FUNCTION inline constexpr float sinf(std::floating_point auto arg) {
+    return xtd::sin(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float sinf(std::integral auto arg) {
+    return xtd::sin(static_cast<float>(arg));
+  }
 
 }  // namespace xtd

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,47 +29,44 @@ endef
 space := $() $()
 comma := $(),$()
 
-# gcc
-CXX := g++
-GCC_TOOLCHAIN := $(abspath $(dir $(shell which $(CXX)))/..)
-GCC_TARGET    := $(shell $(CXX) -dumpmachine)
+# compilation flags used by all compilers and backends
+COMMON_CXXFLAGS := -std=c++20 -O2 -g
+
 # Catch2 needs -Wno-unused-variable
-HOST_CXXFLAGS := -O2 -fPIC -pthread -march=native -Wall -Wextra -Werror -Wfatal-errors -Wno-unused-variable
+# mpfr::real needs -Wno-unused-parameter -Wno-self-assign-overloaded
+HOST_CXXFLAGS := -march=native -Wall -Wextra -Werror -Wfatal-errors -Wno-unused-variable -Wno-unused-parameter -Wno-self-assign-overloaded
 
 # Compiler flags supported by GCC but not by the LLVM-based compilers (clang, hipcc, icpx, etc.)
 LLVM_UNSUPPORTED_CXXFLAGS := --param vect-max-version-for-alias-checks=50 -Werror=format-contains-nul -Wno-non-template-friend -Werror=return-local-addr -Werror=unused-but-set-variable
 
-CXXFLAGS := -std=c++20 $(HOST_CXXFLAGS) -g
-LDFLAGS := -O2 -fPIC -pthread -Wl,-E -lstdc++fs -ldl
+# gcc
+CXX           := g++
+GCC_TOOLCHAIN := $(abspath $(dir $(shell which $(CXX)))/..)
+GCC_TARGET    := $(shell $(CXX) -dumpmachine)
+CXXFLAGS      := $(COMMON_CXXFLAGS) $(HOST_CXXFLAGS)
+LDFLAGS       :=
+$(info Using $(CXX) host compiler installation at $(GCC_TOOLCHAIN) for target $(GCC_TARGET))
 
 # CUDA
 CUDA_BASE := /usr/local/cuda
 # default to the list of all supported major architectures
 CUDA_ARCH := 50 60 70 80 90 100 120
-ifeq ($(wildcard $(CUDA_BASE)),)
+ifeq ($(wildcard $(CUDA_BASE)/bin/nvcc),)
   # CUDA platform not found
   $(info Cannot find an NVIDIA CUDA installation at $(CUDA_BASE), the CUDA tests will not be built.)
-  CUDA_BASE :=
+  override CUDA_BASE :=
 else
-# CUDA platform at $(CUDA_BASE)
-  CUDA_LIBDIR := $(CUDA_BASE)/lib64
-  CUDA_DEPS := $(CUDA_LIBDIR)/libcudart.so
+  # CUDA platform at $(CUDA_BASE)
+  $(info Using NVIDIA CUDA installation at $(CUDA_BASE), $(strip $(shell $(CUDA_BASE)/bin/nvcc --version | grep release | cut -d, -f2-)))
+  CUDA_NVCC     := $(CUDA_BASE)/bin/nvcc
+  CUDA_LIBDIR   := $(CUDA_BASE)/lib64
   # detect the architecture of the NVIDIA GPUs in the system
   CUDA_DETECTED_ARCH := $(shell $(CUDA_BASE)/bin/__nvcc_device_query 2> /dev/null)
   ifneq ($(CUDA_DETECTED_ARCH),)
     CUDA_ARCH := $(CUDA_DETECTED_ARCH)
   endif
-  CUDA_CXXFLAGS := -I$(CUDA_BASE)/include
-  CUDA_LDFLAGS := -L$(CUDA_LIBDIR) -lcudart -lcudadevrt
-  CUDA_NVCC := $(CUDA_BASE)/bin/nvcc
-  define CUFLAGS_template
-    $(2)NVCC_FLAGS := $$(foreach ARCH,$(1),-gencode arch=compute_$$(ARCH),code=[sm_$$(ARCH),compute_$$(ARCH)]) -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --expt-relaxed-constexpr --expt-extended-lambda --generate-line-info --source-in-ptx --display-error-number --threads $$(words $(1)) --cudart=shared
-    $(2)NVCC_COMMON := -std=c++20 -O3 -g $$($(2)NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS)'
-    $(2)CUDA_CUFLAGS := $$($(2)NVCC_COMMON)
-  endef
-  $(eval $(call CUFLAGS_template,$(CUDA_ARCH),))
-  NVCC_COMMON := -std=c++20 -O3 -g $(NVCC_FLAGS) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS)'
-  CUDA_CUFLAGS := $(NVCC_COMMON)
+  CUDA_CXXFLAGS := $(COMMON_CXXFLAGS) $(foreach ARCH,$(CUDA_ARCH),-gencode arch=compute_$(ARCH),code=[sm_$(ARCH),compute_$(ARCH)]) -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --prec-div true --prec-sqrt true --fmad true --expt-relaxed-constexpr --extended-lambda --generate-line-info --source-in-ptx --display-error-number --threads $(words $(CUDA_ARCH)) -ccbin $(CXX) --compiler-options '$(HOST_CXXFLAGS)' -I$(CUDA_BASE)/include
+  CUDA_LDFLAGS  := -L$(CUDA_LIBDIR) -lcudart -lcudadevrt --cudart=shared $(LDFLAGS)
 
   # Make sure the tests can find the CUDA libraries
   export LD_LIBRARY_PATH := $(CUDA_LIBDIR):$(LD_LIBRARY_PATH)
@@ -79,22 +76,22 @@ endif
 ROCM_BASE := /opt/rocm
 # default to the list of all supported architectures
 ROCM_ARCH := gfx900 gfx906 gfx908 gfx90a gfx942 gfx1030 gfx1100 gfx1101 gfx1200 gfx1201
-ifeq ($(wildcard $(ROCM_BASE)),)
+ifeq ($(wildcard $(ROCM_BASE)/bin/hipcc),)
   # ROCm platform not found
   $(info Cannot find an AMD ROCm installation at $(ROCM_BASE), the ROCm tests will not be built.)
-  ROCM_BASE :=
+  override ROCM_BASE :=
 else
   # ROCm platform at $(ROCM_BASE)
+  $(info Using AMD ROCm installation at $(ROCM_BASE), version $(strip $(shell $(ROCM_BASE)/bin/hipcc --version | grep 'HIP version' | cut -d: -f2-)))
   ROCM_LIBDIR := $(ROCM_BASE)/lib
-  ROCM_DEPS := $(ROCM_LIBDIR)/libamdhip64.so
   # detect the architecture of the AMD GPUs in the system
   ROCM_DETECTED_ARCH := $(shell $(ROCM_BASE)/lib/llvm/bin/amdgpu-arch 2> /dev/null | sort -u)
   ifneq ($(ROCM_DETECTED_ARCH),)
     ROCM_ARCH := $(ROCM_DETECTED_ARCH)
   endif
-  ROCM_HIPCC := $(ROCM_BASE)/bin/hipcc
-  HIPCC_CXXFLAGS := -fno-gpu-rdc $(foreach ARCH,$(ROCM_ARCH),--offload-arch=$(ARCH)) $(filter-out $(LLVM_UNSUPPORTED_CXXFLAGS),$(CXXFLAGS)) --target=$(GCC_TARGET) --gcc-toolchain=$(GCC_TOOLCHAIN) -I$(ROCM_BASE)/include/hip -Wno-unused-result
-  HIPCC_LDFLAGS := $(LDFLAGS) --target=$(GCC_TARGET) --gcc-toolchain=$(GCC_TOOLCHAIN)
+  ROCM_HIPCC     := $(ROCM_BASE)/bin/hipcc
+  ROCM_CXXFLAGS := $(filter-out $(LLVM_UNSUPPORTED_CXXFLAGS),$(CXXFLAGS)) $(foreach ARCH,$(ROCM_ARCH),--offload-arch=$(ARCH)) -fhip-fp32-correctly-rounded-divide-sqrt --target=$(GCC_TARGET) --gcc-toolchain=$(GCC_TOOLCHAIN) -I$(ROCM_BASE)/include/hip
+  ROCM_LDFLAGS  := $(LDFLAGS)
 
   # Make sure the tests can find the ROCm libraries
   export LD_LIBRARY_PATH := $(ROCM_LIBDIR):$(LD_LIBRARY_PATH)
@@ -112,7 +109,7 @@ endif
 ifneq ($(ONEAPI_BASE),)
   ifneq ($(wildcard $(ONEAPI_BASE)/setvars.sh),)
     # found Intel oneAPI at $(ONEAPI_BASE)
-    $(info Found an Intel oneAPI installation at $(ONEAPI_BASE))
+    $(info Using Intel oneAPI installation at $(ONEAPI_BASE))
   else
     # Intel oneAPI not found at $(ONEAPI_BASE), set ONEAPI_BASE to an empty value
     $(info Cannot find an Intel oneAPI installation at $(ONEAPI_BASE), the oneAPI tests will not be built.)
@@ -126,7 +123,7 @@ ifeq ($(origin ONEAPI_BASE), undefined)
     ifneq ($(wildcard $(ONEAPI_ROOT)/setvars.sh),)
       # found Intel oneAPI at $(ONEAPI_ROOT)
       ONEAPI_BASE := $(ONEAPI_ROOT)
-      $(info Found an Intel oneAPI installation at $(ONEAPI_BASE))
+      $(info Using Intel oneAPI installation at $(ONEAPI_BASE), version $(strip $(shell $(ONEAPI_BASE)/compiler/latest/bin/icpx --version | sed -n -e's#Intel(R) oneAPI DPC++/C++ Compiler##p')))
     endif
   endif
 endif
@@ -136,7 +133,7 @@ ifeq ($(origin ONEAPI_BASE), undefined)
   ifneq ($(wildcard /opt/intel/oneapi/setvars.sh),)
     # found Intel oneAPI at /opt/intel/oneapi
     ONEAPI_BASE := /opt/intel/oneapi
-    $(info Found an Intel oneAPI installation at $(ONEAPI_BASE))
+    $(info Using Intel oneAPI installation at $(ONEAPI_BASE))
   endif
 endif
 
@@ -152,8 +149,6 @@ ifneq ($(ONEAPI_BASE),)
   SYCL_BASE         := $(ONEAPI_BASE)/compiler/latest
   SYCL_LIBDIR       := $(SYCL_BASE)/lib
   SYCL_CXX          := $(SYCL_BASE)/bin/icpx
-  SYCL_CXXFLAGS     := $(filter-out $(LLVM_UNSUPPORTED_CXXFLAGS),$(CXXFLAGS))
-  SYCL_LDFLAGS      :=
   SYCL_TARGETS      := spir64_x86_64 spir64
   ifdef CUDA_BASE
     ifneq ($(wildcard $(SYCL_LIBDIR)/libur_adapter_cuda.so),)
@@ -180,7 +175,8 @@ ifneq ($(ONEAPI_BASE),)
       SYCL_ROCM_FLAGS := --rocm-path=$(ROCM_BASE)
     endif
   endif
-  SYCL_FLAGS        := -fsycl -fsycl-targets=$(subst $(space),$(comma),$(SYCL_TARGETS)) $(SYCL_CUDA_FLAGS) $(SYCL_ROCM_FLAGS) -fp-model=precise
+  SYCL_CXXFLAGS     := $(filter-out $(LLVM_UNSUPPORTED_CXXFLAGS),$(CXXFLAGS)) -fsycl -fsycl-targets=$(subst $(space),$(comma),$(SYCL_TARGETS)) $(SYCL_CUDA_FLAGS) $(SYCL_ROCM_FLAGS) -fp-model=precise
+  SYCL_LDFLAGS      := $(LDFLAGS)
 
   # Check for Intel GPU existence
   #SYCL_LS := $(shell mktemp)
@@ -197,22 +193,44 @@ endif
 
 # xtd
 XTD_BASE := $(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST))))/..)
+$(info Using xtd library at $(XTD_BASE))
+LIB_CFLAGS  := -I$(XTD_BASE)/include -I$(XTD_BASE)/test
+LIB_LDFLAGS :=
+
+# external libraries downloaded and installed locally
+EXTERNAL_BASE := $(XTD_BASE)/test/external
 
 # external Catch2 library
-CATCH2_INCLUDE := $(XTD_BASE)/test/external/catch2/include/catch.hpp
+CATCH2_INCLUDE := $(EXTERNAL_BASE)/catch2/include/catch.hpp
+$(info Using Catch2 library at $(EXTERNAL_BASE)/catch2)
+LIB_CFLAGS  += -I$(patsubst %/,%,$(dir $(CATCH2_INCLUDE)))
+LIB_LDFLAGS +=
 
 .PHONY: external_catch2
 external_catch2: $(CATCH2_INCLUDE)
 
 $(CATCH2_INCLUDE):
 	mkdir -p $(dir $@)
-	wget https://github.com/catchorg/Catch2/releases/download/v2.13.10/catch.hpp -O $@
+	curl -s -S -L https://github.com/catchorg/Catch2/releases/download/v2.13.10/catch.hpp -o $@
 
-LIB_INCLUDE := -I$(XTD_BASE)/include -I$(XTD_BASE)/test -I$(dir $(CATCH2_INCLUDE))
+# external mpfr::real library
+MPFR_REAL_INCLUDE := $(EXTERNAL_BASE)/mpfr_real_v0.0.9-alpha/real.hpp
+$(info Using mpfr::real library at $(EXTERNAL_BASE)/mpfr_real_v0.0.9-alpha)
+LIB_CFLAGS  += -I$(patsubst %/,%,$(dir $(MPFR_REAL_INCLUDE)))
+LIB_LDFLAGS += -lmpfr
+
+.PHONY: external_mpfr_real
+external_mpfr_real: $(MPFR_REAL_INCLUDE)
+
+$(MPFR_REAL_INCLUDE):
+	mkdir -p $(dir $@)
+	curl -s -S -L https://www.chschneider.eu/programming/mpfr_real/mpfr_real_v0.0.9-alpha.tar.gz | tar xz -C $(EXTERNAL_BASE)
+
+$(info -------------------------------------------------------------------------------)
 
 # xtd tests
 SUBDIRS := $(wildcard $(XTD_BASE)/test/*/)
-TARGETS_ALL := $(filter-out common, $(filter-out external, $(notdir $(patsubst %/,%,$(SUBDIRS)))))
+TARGETS_ALL := $(filter-out common external, $(notdir $(patsubst %/,%,$(SUBDIRS))))
 
 define TEST_template
 build: build_$(1)
@@ -221,7 +239,7 @@ build: build_$(1)
 build_$(1): prereq_$(1)
 
 .PHONY: prereq_$(1)
-prereq_$(1): external_catch2 $(1)/bin
+prereq_$(1): external_catch2 external_mpfr_real $(1)/bin
 
 run: run_$(1)
 
@@ -244,7 +262,7 @@ build_$(1): build_$(1)_cpu
 build_$(1)_cpu: $(1)/bin/$(1)_t_cc
 
 $(1)/bin/$(1)_t_cc: $(1)/$(1)_t.cc | prereq_$(1)
-	$(CXX) $(CXXFLAGS) $(LIB_INCLUDE) $$< -o $$@
+	$(CXX) $(CXXFLAGS) $(LIB_CFLAGS) $$< $(LDFLAGS) $(LIB_LDFLAGS) -o $$@
 
 run_$(1): run_$(1)_cpu
 
@@ -260,7 +278,7 @@ build_$(1): build_$(1)_cuda
 build_$(1)_cuda: $(1)/bin/$(1)_t_cuda
 
 $(1)/bin/$(1)_t_cuda: $(1)/$(1)_t.cu | prereq_$(1)
-	$(CUDA_NVCC) $(CUDA_CXXFLAGS) $(CUDA_LDFLAGS) $(CUDA_CUFLAGS) $(LIB_INCLUDE) $$< -o $$@
+	$(CUDA_NVCC) $(CUDA_CXXFLAGS) $(LIB_CFLAGS) $$< $(CUDA_LDFLAGS) $(LIB_LDFLAGS) -o $$@
 
 run_$(1): run_$(1)_cuda
 
@@ -277,7 +295,7 @@ build_$(1): build_$(1)_hip
 build_$(1)_hip: $(1)/bin/$(1)_t_hip
 
 $(1)/bin/$(1)_t_hip: $(1)/$(1)_t.hip.cc | prereq_$(1)
-	$(ROCM_HIPCC) $(HIPCC_CXXFLAGS) $(HIPCC_LDFLAGS) $(LIB_INCLUDE) $$< -o $$@
+	$(ROCM_HIPCC) $(ROCM_CXXFLAGS) $(LIB_CFLAGS) $$< $(ROCM_LDFLAGS) $(LIB_LDFLAGS) -o $$@
 
 run_$(1): run_$(1)_hip
 
@@ -294,7 +312,7 @@ build_$(1): build_$(1)_sycl
 build_$(1)_sycl: $(1)/bin/$(1)_t_sycl
 
 $(1)/bin/$(1)_t_sycl: $(1)/$(1)_t.sycl.cc | prereq_$(1)
-	$(SYCL_CXX) $(SYCL_CXXFLAGS) $(SYCL_LDFLAGS) $(SYCL_FLAGS) $(LIB_INCLUDE) $$< -o $$@
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $(LIB_CFLAGS) $$< $(SYCL_LDFLAGS) $(LIB_LDFLAGS) -o $$@
 
 run_$(1): run_$(1)_sycl
 

--- a/test/common/compare.h
+++ b/test/common/compare.h
@@ -14,7 +14,7 @@
 #include <catch.hpp>
 
 template <std::floating_point T>
-void compare(T result, T reference, int ULPs = 1) {
+void compare(T result, T reference, int ulps = 0) {
   switch (std::fpclassify(reference)) {
     case FP_INFINITE:
       CHECK(std::isinf(result));
@@ -23,11 +23,11 @@ void compare(T result, T reference, int ULPs = 1) {
       CHECK(std::isnan(result));
       break;
     case FP_ZERO:
-      CHECK_THAT(result, Catch::Matchers::WithinULP(0., ULPs));
+      CHECK_THAT(result, Catch::Matchers::WithinULP(0., ulps));
       break;
     case FP_NORMAL:
     case FP_SUBNORMAL:
     default:
-      CHECK_THAT(result, Catch::Matchers::WithinULP(reference, ULPs));
+      CHECK_THAT(result, Catch::Matchers::WithinULP(reference, ulps));
   }
 }

--- a/test/common/cpu_test.h
+++ b/test/common/cpu_test.h
@@ -9,31 +9,53 @@
 // C++ standard headers
 #include <vector>
 
+// mpfr::real headers
+#include <real.hpp>
+
 // test headers
 #include "compare.h"
 
-template <typename ResultType, typename InputType, ResultType (*XtdFunc)(InputType), ResultType (*StdFunc)(InputType)>
-inline void test(std::vector<double> const& values) {
+static constexpr auto single_prec = 24;
+static constexpr auto double_prec = 53;
+using mpfr_single = mpfr::real<single_prec, MPFR_RNDN>;
+using mpfr_double = mpfr::real<double_prec, MPFR_RNDN>;
+
+template <
+    typename ResultType,
+    typename InputType,
+    ResultType (*XtdFunc)(InputType),
+    typename std::enable_if<mpfr::type_traits<mpfr_double, mpfr_double, true>::enable_math_funcs,
+                            const mpfr_double>::type (*RefFunc)(const mpfr_double&)>
+inline void test(std::vector<double> const& values, int ulps = 0) {
   for (double value : values) {
     // convert the input data to the type to be tested
     InputType input = static_cast<InputType>(value);
     // execute the xtd function
     ResultType result = XtdFunc(input);
     // compare the result with the std reference
-    ResultType reference = StdFunc(input);
-    compare(result, reference);
+    INFO(input);
+    ResultType reference;
+    RefFunc(static_cast<mpfr_double>(input)).conv(reference);
+    compare(result, reference, ulps);
   }
 }
 
-template <typename ResultType, typename InputType, ResultType (*XtdFunc)(InputType), ResultType (*StdFunc)(float)>
-inline void test_f(std::vector<double> const& values) {
+template <
+    typename ResultType,
+    typename InputType,
+    ResultType (*XtdFunc)(InputType),
+    typename std::enable_if<mpfr::type_traits<mpfr_single, mpfr_single, true>::enable_math_funcs,
+                            const mpfr_single>::type (*RefFunc)(const mpfr_single&)>
+inline void test_f(std::vector<double> const& values, int ulps = 0) {
   for (double value : values) {
     // convert the input data to the type to be tested
     InputType input = static_cast<InputType>(value);
     // execute the xtd function
     ResultType result = XtdFunc(input);
     // compare the result with the std reference
-    ResultType reference = StdFunc(static_cast<float>(input));
-    compare(result, reference);
+    INFO(input);
+    ResultType reference;
+    RefFunc(static_cast<mpfr_single>(input)).conv(reference);
+    compare(result, reference, ulps);
   }
 }

--- a/test/common/hip_test.h
+++ b/test/common/hip_test.h
@@ -12,9 +12,17 @@
 // HIP headers
 #include <hip/hip_runtime.h>
 
+// mpfr::real headers
+#include <real.hpp>
+
 // test headers
 #include "compare.h"
 #include "hip_check.h"
+
+static constexpr auto single_prec = 24;
+static constexpr auto double_prec = 53;
+using mpfr_single = mpfr::real<single_prec, MPFR_RNDN>;
+using mpfr_double = mpfr::real<double_prec, MPFR_RNDN>;
 
 template <typename ResultType, typename InputType, ResultType (*XtdFunc)(InputType)>
 __global__ static void kernel(InputType const* input, ResultType* result, int size) {
@@ -25,8 +33,13 @@ __global__ static void kernel(InputType const* input, ResultType* result, int si
   }
 }
 
-template <typename ResultType, typename InputType, ResultType (*XtdFunc)(InputType), ResultType (*StdFunc)(InputType)>
-inline void test(hipStream_t queue, std::vector<double> const& values) {
+template <
+    typename ResultType,
+    typename InputType,
+    ResultType (*XtdFunc)(InputType),
+    typename std::enable_if<mpfr::type_traits<mpfr_double, mpfr_double, true>::enable_math_funcs,
+                            const mpfr_double>::type (*RefFunc)(const mpfr_double&)>
+inline void test(hipStream_t queue, std::vector<double> const& values, int ulps = 0) {
   int size = values.size();
 
   // convert the input data to the type to be tested and copy them to the GPU
@@ -53,13 +66,20 @@ inline void test(hipStream_t queue, std::vector<double> const& values) {
 
   // compare the xtd results with std reference results
   for (int i = 0; i < size; ++i) {
-    ResultType reference = std::sin(input_h[i]);
-    compare(result_h[i], reference);
+    INFO(input_h[i]);
+    ResultType reference;
+    RefFunc(static_cast<mpfr_double>(input_h[i])).conv(reference);
+    compare(result_h[i], reference, ulps);
   }
 }
 
-template <typename ResultType, typename InputType, ResultType (*XtdFunc)(InputType), ResultType (*StdFunc)(float)>
-inline void test_f(hipStream_t queue, std::vector<double> const& values) {
+template <
+    typename ResultType,
+    typename InputType,
+    ResultType (*XtdFunc)(InputType),
+    typename std::enable_if<mpfr::type_traits<mpfr_single, mpfr_single, true>::enable_math_funcs,
+                            const mpfr_single>::type (*RefFunc)(const mpfr_single&)>
+inline void test_f(hipStream_t queue, std::vector<double> const& values, int ulps = 0) {
   int size = values.size();
 
   // convert the input data to the type to be tested and copy them to the GPU
@@ -86,7 +106,9 @@ inline void test_f(hipStream_t queue, std::vector<double> const& values) {
 
   // compare the xtd results with std reference results
   for (int i = 0; i < size; ++i) {
-    ResultType reference = StdFunc(static_cast<float>(input_h[i]));
-    compare(result_h[i], reference);
+    INFO(input_h[i]);
+    ResultType reference;
+    RefFunc(static_cast<mpfr_single>(input_h[i])).conv(reference);
+    compare(result_h[i], reference, ulps);
   }
 }

--- a/test/sin/sin_t.cc
+++ b/test/sin/sin_t.cc
@@ -12,6 +12,9 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
+// mpfr::real headers
+#include <real.hpp>
+
 // xtd headers
 #include "xtd/math/sin.h"
 
@@ -23,29 +26,26 @@ TEST_CASE("xtd::sin", "[sin][cpu]") {
   std::vector<double> values = generate_input_values();
 
   SECTION("float xtd::sin(float)") {
-    test<float, float, xtd::sin, std::sin>(values);
+    test<float, float, xtd::sin, mpfr::sin>(values, 1);
   }
 
   SECTION("double xtd::sin(double)") {
-    test<double, double, xtd::sin, std::sin>(values);
+    test<double, double, xtd::sin, mpfr::sin>(values, 1);
   }
 
   SECTION("double xtd::sin(int)") {
-    test<double, int, xtd::sin, std::sin>(values);
+    test<double, int, xtd::sin, mpfr::sin>(values, 1);
   }
 
-  // Note: GCC prior to v14.1 and clang prior to v19.1 do not provide std::sinf().
-  // As a workarund, use C sinf().
-
   SECTION("float xtd::sinf(float)") {
-    test_f<float, float, xtd::sinf, ::sinf>(values);
+    test_f<float, float, xtd::sinf, mpfr::sin>(values, 1);
   }
 
   SECTION("float xtd::sinf(double)") {
-    test_f<float, double, xtd::sinf, ::sinf>(values);
+    test_f<float, double, xtd::sinf, mpfr::sin>(values, 1);
   }
 
   SECTION("float xtd::sinf(int)") {
-    test_f<float, int, xtd::sinf, ::sinf>(values);
+    test_f<float, int, xtd::sinf, mpfr::sin>(values, 1);
   }
 }

--- a/test/sin/sin_t.cu
+++ b/test/sin/sin_t.cu
@@ -19,6 +19,9 @@ using namespace std::literals;
 // CUDA headers
 #include <cuda_runtime.h>
 
+// mpfr::real headers
+#include <real.hpp>
+
 // xtd headers
 #include "xtd/math/sin.h"
 
@@ -51,30 +54,27 @@ TEST_CASE("xtd::sin", "[sin][cuda]") {
       CUDA_CHECK(cudaStreamCreate(&queue));
 
       SECTION("float xtd::sin(float)") {
-        test<float, float, xtd::sin, std::sin>(queue, values);
+        test<float, float, xtd::sin, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("double xtd::sin(double)") {
-        test<double, double, xtd::sin, std::sin>(queue, values);
+        test<double, double, xtd::sin, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("double xtd::sin(int)") {
-        test<double, int, xtd::sin, std::sin>(queue, values);
+        test<double, int, xtd::sin, mpfr::sin>(queue, values, 1);
       }
 
-      // Note: GCC prior to v14.1 and clang prior to v19.1 do not provide std::sinf().
-      // As a workarund, use C sinf().
-
       SECTION("float xtd::sinf(float)") {
-        test_f<float, float, xtd::sinf, ::sinf>(queue, values);
+        test_f<float, float, xtd::sinf, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("float xtd::sinf(double)") {
-        test_f<float, double, xtd::sinf, ::sinf>(queue, values);
+        test_f<float, double, xtd::sinf, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("float xtd::sinf(int)") {
-        test_f<float, int, xtd::sinf, ::sinf>(queue, values);
+        test_f<float, int, xtd::sinf, mpfr::sin>(queue, values, 1);
       }
 
       CUDA_CHECK(cudaStreamDestroy(queue));

--- a/test/sin/sin_t.hip.cc
+++ b/test/sin/sin_t.hip.cc
@@ -19,6 +19,9 @@ using namespace std::literals;
 // HIP headers
 #include <hip/hip_runtime.h>
 
+// mpfr::real headers
+#include <real.hpp>
+
 // xtd headers
 #include "xtd/math/sin.h"
 
@@ -51,28 +54,27 @@ TEST_CASE("xtd::sin", "[sin][hip]") {
       HIP_CHECK(hipStreamCreate(&queue));
 
       SECTION("float xtd::sin(float)") {
-        test<float, float, xtd::sin, std::sin>(queue, values);
+        test<float, float, xtd::sin, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("double xtd::sin(double)") {
-        test<double, double, xtd::sin, std::sin>(queue, values);
+        test<double, double, xtd::sin, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("double xtd::sin(int)") {
-        // Note: HIP/ROCm does not provide the std::sin() overload for integer arguments.
-        test<double, int, xtd::sin, [](int arg) { return std::sin(static_cast<double>(arg)); }>(queue, values);
+        test<double, int, xtd::sin, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("float xtd::sinf(float)") {
-        test_f<float, float, xtd::sinf, std::sinf>(queue, values);
+        test_f<float, float, xtd::sinf, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("float xtd::sinf(double)") {
-        test_f<float, double, xtd::sinf, std::sinf>(queue, values);
+        test_f<float, double, xtd::sinf, mpfr::sin>(queue, values, 1);
       }
 
       SECTION("float xtd::sinf(int)") {
-        test_f<float, int, xtd::sinf, std::sinf>(queue, values);
+        test_f<float, int, xtd::sinf, mpfr::sin>(queue, values, 1);
       }
 
       HIP_CHECK(hipStreamDestroy(queue));

--- a/test/sin/sin_t.sycl.cc
+++ b/test/sin/sin_t.sycl.cc
@@ -17,6 +17,9 @@
 // SYCL headers
 #include <sycl/sycl.hpp>
 
+// mpfr::real headers
+#include <real.hpp>
+
 // xtd headers
 #include "xtd/math/sin.h"
 
@@ -35,30 +38,27 @@ TEST_CASE("xtd::sin", "[sin][sycl]") {
             sycl::queue queue{device, sycl::property::queue::in_order()};
 
             SECTION("float xtd::sin(float)") {
-              test<float, float, xtd::sin, std::sin>(queue, values);
+              test<float, float, xtd::sin, mpfr::sin>(queue, values, 2);
             }
 
             SECTION("double xtd::sin(double)") {
-              test<double, double, xtd::sin, std::sin>(queue, values);
+              test<double, double, xtd::sin, mpfr::sin>(queue, values, 1);
             }
 
             SECTION("double xtd::sin(int)") {
-              test<double, int, xtd::sin, std::sin>(queue, values);
+              test<double, int, xtd::sin, mpfr::sin>(queue, values, 1);
             }
 
-            // Note: clang prior to v19.1 does not provide std::sinf().
-            // As a workarund, use C sinf().
-
             SECTION("float xtd::sinf(float)") {
-              test_f<float, float, xtd::sinf, ::sinf>(queue, values);
+              test_f<float, float, xtd::sinf, mpfr::sin>(queue, values, 2);
             }
 
             SECTION("float xtd::sinf(double)") {
-              test_f<float, double, xtd::sinf, ::sinf>(queue, values);
+              test_f<float, double, xtd::sinf, mpfr::sin>(queue, values, 2);
             }
 
             SECTION("float xtd::sinf(int)") {
-              test_f<float, int, xtd::sinf, ::sinf>(queue, values);
+              test_f<float, int, xtd::sinf, mpfr::sin>(queue, values, 2);
             }
 
           } catch (sycl::exception const &e) {


### PR DESCRIPTION
Rewrite the tests to use the GNU MPFR arbitrary precision functions to compute the reference values, and the accuracy of each back-end for the comparisons.

GNU MPFR is used through the `mpfr::real` template-based C++ wrapper.

The accuracy in ULPs of the implementation of the mathematical functions for each back-end is documented in the README.md, with links to the documentation of each library.

Clean up and reorganise the compilation flags.