### PR TITLE
Reimplement and test additional xtd functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ erff / erf       |         4  |         4
 exp10f / exp10   |         1  |         1
 exp2f / exp2     |         1  |         1
 expf / exp       |         1  |         1
-expm1f / expm1   |         1  |         1
+expm1f / expm1   |         1  |         2†
 fmaf / fma       |         0  |         0
 fmodf / fmod     |         0  |         0
 hypotf / hypot   |         1  |         1
@@ -160,12 +160,15 @@ sincosf / sincos |         1  |         1
 sinf / sin       |         1  |         1
 sinhf / sinh     |         1  |         1
 sqrtf / sqrt     |         1  |         1
-tanf / tan       |         1  |         1
+tanf / tan       |         2‡ |         2‡
 tanhf / tanh     |         2  |         1
 tgammaf / tgamma |         6  |         6
 y0f / y0         |       n/a  |       n/a
 y1f / y1         |       n/a  |       n/a
 ynf / yn         |       n/a  |       n/a
+
+  - † 1 ULP for x ∈ [-10., +10.] according to the documentation
+  - ‡ 1 ULP for x ∈ [-1.47 π, +1.47 π] according to the documentation
 
 Note: in some cases the accuracy is documented only for a small range of values.
 

--- a/include/xtd/math/cbrt.h
+++ b/include/xtd/math/cbrt.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float cbrt(float x) {
+  /* Computes the cubic root of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float cbrt(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::cbrt(x);
+    return ::cbrtf(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::cbrt(x);
+    return ::cbrtf(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::cbrt(x);
+    return sycl::cbrt(arg);
 #else
-    // standard C++ code
-    return std::cbrt(x);
+    // standard C/C++ code
+    return ::cbrtf(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double cbrt(double x) {
+  /* Computes the cubic root of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double cbrt(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::cbrt(x);
+    return ::cbrt(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::cbrt(x);
+    return ::cbrt(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::cbrt(x);
+    return sycl::cbrt(arg);
 #else
-    // standard C++ code
-    return std::cbrt(x);
+    // standard C/C++ code
+    return ::cbrt(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float cbrtf(float x) { return cbrt(x); }
+  /* Computes the cubic root of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double cbrt(std::integral auto arg) {
+    return xtd::cbrt(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double cbrt(T x) {
-    return cbrt(static_cast<double>(x));
+  /* Computes the cubic root of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float cbrtf(std::floating_point auto arg) {
+    return xtd::cbrt(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float cbrtf(std::integral auto arg) {
+    return xtd::cbrt(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/ceil.h
+++ b/include/xtd/math/ceil.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float ceil(float x) {
+  /* Computes the smallest integral value that is not less than arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float ceil(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::ceil(x);
+    return ::ceilf(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::ceil(x);
+    return ::ceilf(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::ceil(x);
+    return sycl::ceil(arg);
 #else
-    // standard C++ code
-    return std::ceil(x);
+    // standard C/C++ code
+    return ::ceilf(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double ceil(double x) {
+  /* Computes the smallest integral value that is not less than arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double ceil(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::ceil(x);
+    return ::ceil(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::ceil(x);
+    return ::ceil(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::ceil(x);
+    return sycl::ceil(arg);
 #else
-    // standard C++ code
-    return std::ceil(x);
+    // standard C/C++ code
+    return ::ceil(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float ceilf(float x) { return ceil(x); }
+  /* Computes the smallest integral value that is not less than arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double ceil(std::integral auto arg) {
+    return xtd::ceil(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double ceil(T x) {
-    return ceil(static_cast<double>(x));
+  /* Computes the smallest integral value that is not less than arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float ceilf(std::floating_point auto arg) {
+    return xtd::ceil(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float ceilf(std::integral auto arg) {
+    return xtd::ceil(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/cos.h
+++ b/include/xtd/math/cos.h
@@ -1,22 +1,39 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float cos(float arg) {
+  /* Computes the cosine of arg (measured in radians), in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float cos(float arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::cosf(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::cosf(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::cos(arg);
+#else
+    // standard C/C++ code
+    return ::cosf(arg);
+#endif
+  }
+
+  /* Computes the cosine of arg (measured in radians), in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double cos(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::cos(arg);
@@ -27,34 +44,24 @@ namespace xtd {
     // SYCL device code
     return sycl::cos(arg);
 #else
-    // standard C++ code
-    return std::cos(arg);
+    // standard C/C++ code
+    return ::cos(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr double cos(double arg) {
-#if defined(XTD_TARGET_CUDA)
-    // CUDA device code
-    return ::cos(arg);
-#elif defined(XTD_TARGET_HIP)
-    // HIP/ROCm device code
-    return ::cos(arg);
-#elif defined(XTD_TARGET_SYCL)
-    // SYCL device code
-    return sycl::cos(arg);
-#else
-    // standard C++ code
-    return std::cos(arg);
-#endif
+  /* Computes the cosine of arg (measured in radians), in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double cos(std::integral auto arg) {
+    return xtd::cos(static_cast<double>(arg));
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float cosf(float arg) { return cos(arg); }
-
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double cos(T arg) {
-    return cos(static_cast<double>(arg));
+  /* Computes the cosine of arg (measured in radians), in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float cosf(std::floating_point auto arg) {
+    return xtd::cos(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float cosf(std::integral auto arg) {
+    return xtd::cos(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/cosh.h
+++ b/include/xtd/math/cosh.h
@@ -1,22 +1,39 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float cosh(float arg) {
+  /* Computes the hyperbolic cosine of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float cosh(float arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::coshf(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::coshf(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::cosh(arg);
+#else
+    // standard C/C++ code
+    return ::coshf(arg);
+#endif
+  }
+
+  /* Computes the hyperbolic cosine of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double cosh(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::cosh(arg);
@@ -27,34 +44,24 @@ namespace xtd {
     // SYCL device code
     return sycl::cosh(arg);
 #else
-    // standard C++ code
-    return std::cosh(arg);
+    // standard C/C++ code
+    return ::cosh(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr double cosh(double arg) {
-#if defined(XTD_TARGET_CUDA)
-    // CUDA device code
-    return ::cosh(arg);
-#elif defined(XTD_TARGET_HIP)
-    // HIP/ROCm device code
-    return ::cosh(arg);
-#elif defined(XTD_TARGET_SYCL)
-    // SYCL device code
-    return sycl::cosh(arg);
-#else
-    // standard C++ code
-    return std::cosh(arg);
-#endif
+  /* Computes the hyperbolic cosine of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double cosh(std::integral auto arg) {
+    return xtd::cosh(static_cast<double>(arg));
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float coshf(float arg) { return cosh(arg); }
-
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double cosh(T arg) {
-    return cosh(static_cast<double>(arg));
+  /* Computes the hyperbolic cosine of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float coshf(std::floating_point auto arg) {
+    return xtd::cosh(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float coshf(std::integral auto arg) {
+    return xtd::cosh(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/exp.h
+++ b/include/xtd/math/exp.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float exp(float x) {
+  /* Computes the exponential value of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float exp(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::exp(x);
+    return ::expf(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::exp(x);
+    return ::expf(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::exp(x);
+    return sycl::exp(arg);
 #else
-    // standard C++ code
-    return std::exp(x);
+    // standard C/C++ code
+    return ::expf(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double exp(double x) {
+  /* Computes the exponential value of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double exp(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::exp(x);
+    return ::exp(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::exp(x);
+    return ::exp(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::exp(x);
+    return sycl::exp(arg);
 #else
-    // standard C++ code
-    return std::exp(x);
+    // standard C/C++ code
+    return ::exp(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float expf(float x) { return exp(x); }
+  /* Computes the exponential value of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double exp(std::integral auto arg) {
+    return xtd::exp(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double exp(T x) {
-    return exp(static_cast<double>(x));
+  /* Computes the exponential value of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float expf(std::floating_point auto arg) {
+    return xtd::exp(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float expf(std::integral auto arg) {
+    return xtd::exp(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/exp2.h
+++ b/include/xtd/math/exp2.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float exp2(float x) {
+  /* Computes the base-2 exponential value of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float exp2(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::exp2(x);
+    return ::exp2f(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::exp2(x);
+    return ::exp2f(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::exp2(x);
+    return sycl::exp2(arg);
 #else
-    // standard C++ code
-    return std::exp2(x);
+    // standard C/C++ code
+    return ::exp2f(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double exp2(double x) {
+  /* Computes the base-2 exponential value of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double exp2(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::exp2(x);
+    return ::exp2(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::exp2(x);
+    return ::exp2(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::exp2(x);
+    return sycl::exp2(arg);
 #else
-    // standard C++ code
-    return std::exp2(x);
+    // standard C/C++ code
+    return ::exp2(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float exp2f(float x) { return exp2(x); }
+  /* Computes the base-2 exponential value of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double exp2(std::integral auto arg) {
+    return xtd::exp2(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double exp2(T x) {
-    return exp2(static_cast<double>(x));
+  /* Computes the base-2 exponential value of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float exp2f(std::floating_point auto arg) {
+    return xtd::exp2(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float exp2f(std::integral auto arg) {
+    return xtd::exp2(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/expm1.h
+++ b/include/xtd/math/expm1.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float expm1(float x) {
+  /* Computes he exponential value of arg, minus 1, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float expm1(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::expm1(x);
+    return ::expm1f(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::expm1(x);
+    return ::expm1f(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::expm1(x);
+    return sycl::expm1(arg);
 #else
-    // standard C++ code
-    return std::expm1(x);
+    // standard C/C++ code
+    return ::expm1f(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double expm1(double x) {
+  /* Computes he exponential value of arg, minus 1, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double expm1(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::expm1(x);
+    return ::expm1(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::expm1(x);
+    return ::expm1(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::expm1(x);
+    return sycl::expm1(arg);
 #else
-    // standard C++ code
-    return std::expm1(x);
+    // standard C/C++ code
+    return ::expm1(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float expm1f(float x) { return expm1(x); }
+  /* Computes he exponential value of arg, minus 1, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double expm1(std::integral auto arg) {
+    return xtd::expm1(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double expm1(T x) {
-    return expm1(static_cast<double>(x));
+  /* Computes he exponential value of arg, minus 1, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float expm1f(std::floating_point auto arg) {
+    return xtd::expm1(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float expm1f(std::integral auto arg) {
+    return xtd::expm1(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/floor.h
+++ b/include/xtd/math/floor.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float floor(float x) {
+  /* Computes the largest integral value that is not greater than arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float floor(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::floor(x);
+    return ::floorf(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::floor(x);
+    return ::floorf(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::floor(x);
+    return sycl::floor(arg);
 #else
-    // standard C++ code
-    return std::floor(x);
+    // standard C/C++ code
+    return ::floorf(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double floor(double x) {
+  /* Computes the largest integral value that is not greater than arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double floor(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::floor(x);
+    return ::floor(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::floor(x);
+    return ::floor(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::floor(x);
+    return sycl::floor(arg);
 #else
-    // standard C++ code
-    return std::floor(x);
+    // standard C/C++ code
+    return ::floor(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float floorf(float x) { return floor(x); }
+  /* Computes the largest integral value that is not greater than arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double floor(std::integral auto arg) {
+    return xtd::floor(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double floor(T x) {
-    return floor(static_cast<double>(x));
+  /* Computes the largest integral value that is not greater than arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float floorf(std::floating_point auto arg) {
+    return xtd::floor(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float floorf(std::integral auto arg) {
+    return xtd::floor(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/log.h
+++ b/include/xtd/math/log.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float log(float x) {
+  /* Computes the natural logarithm of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float log(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::log(x);
+    return ::logf(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::log(x);
+    return ::logf(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::log(x);
+    return sycl::log(arg);
 #else
-    // standard C++ code
-    return std::log(x);
+    // standard C/C++ code
+    return ::logf(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double log(double x) {
+  /* Computes the natural logarithm of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double log(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::log(x);
+    return ::log(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::log(x);
+    return ::log(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::log(x);
+    return sycl::log(arg);
 #else
-    // standard C++ code
-    return std::log(x);
+    // standard C/C++ code
+    return ::log(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float logf(float x) { return log(x); }
+  /* Computes the natural logarithm of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double log(std::integral auto arg) {
+    return xtd::log(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double log(T x) {
-    return log(static_cast<double>(x));
+  /* Computes the natural logarithm of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float logf(std::floating_point auto arg) {
+    return xtd::log(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float logf(std::integral auto arg) {
+    return xtd::log(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/log10.h
+++ b/include/xtd/math/log10.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float log10(float x) {
+  /* Computes the base-10 logarithm of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float log10(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::log10(x);
+    return ::log10f(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::log10(x);
+    return ::log10f(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::log10(x);
+    return sycl::log10(arg);
 #else
-    // standard C++ code
-    return std::log10(x);
+    // standard C/C++ code
+    return ::log10f(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double log10(double x) {
+  /* Computes the base-10 logarithm of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double log10(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::log10(x);
+    return ::log10(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::log10(x);
+    return ::log10(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::log10(x);
+    return sycl::log10(arg);
 #else
-    // standard C++ code
-    return std::log10(x);
+    // standard C/C++ code
+    return ::log10(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float log10f(float x) { return log10(x); }
+  /* Computes the base-10 logarithm of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double log10(std::integral auto arg) {
+    return xtd::log10(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double log10(T x) {
-    return log10(static_cast<double>(x));
+  /* Computes the base-10 logarithm of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float log10f(std::floating_point auto arg) {
+    return xtd::log10(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float log10f(std::integral auto arg) {
+    return xtd::log10(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/log1p.h
+++ b/include/xtd/math/log1p.h
@@ -1,56 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
+
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float log1p(float x) {
+  /* Computes the natural logarithm of (1 + arg), in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float log1p(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::log1p(x);
+    return ::log1pf(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::log1p(x);
+    return ::log1pf(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::log1p(x);
+    return sycl::log1p(arg);
 #else
-    // standard C++ code
-    return std::log1p(x);
+    // standard C/C++ code
+    return ::log1pf(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double log1p(double x) {
+  /* Computes the natural logarithm of (1 + arg), in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double log1p(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::log1p(x);
+    return ::log1p(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::log1p(x);
+    return ::log1p(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::log1p(x);
+    return sycl::log1p(arg);
 #else
-    // standard C++ code
-    return std::log1p(x);
+    // standard C/C++ code
+    return ::log1p(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float log1pf(float x) { return log1p(x); }
+  /* Computes the natural logarithm of (1 + arg), in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double log1p(std::integral auto arg) {
+    return xtd::log1p(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double log1p(T x) {
-    return log1p(static_cast<double>(x));
+  /* Computes the natural logarithm of (1 + arg), in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float log1pf(std::floating_point auto arg) {
+    return xtd::log1p(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float log1pf(std::integral auto arg) {
+    return xtd::log1p(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/log2.h
+++ b/include/xtd/math/log2.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float log2(float x) {
+  /* Computes the base-2 logarithm of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float log2(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::log2(x);
+    return ::log2f(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::log2(x);
+    return ::log2f(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::log2(x);
+    return sycl::log2(arg);
 #else
-    // standard C++ code
-    return std::log2(x);
+    // standard C/C++ code
+    return ::log2f(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double log2(double x) {
+  /* Computes the base-2 logarithm of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double log2(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::log2(x);
+    return ::log2(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::log2(x);
+    return ::log2(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::log2(x);
+    return sycl::log2(arg);
 #else
-    // standard C++ code
-    return std::log2(x);
+    // standard C/C++ code
+    return ::log2(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float log2f(float x) { return log2(x); }
+  /* Computes the base-2 logarithm of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double log2(std::integral auto arg) {
+    return xtd::log2(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double log2(T x) {
-    return log2(static_cast<double>(x));
+  /* Computes the base-2 logarithm of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float log2f(std::floating_point auto arg) {
+    return xtd::log2(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float log2f(std::integral auto arg) {
+    return xtd::log2(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/sinh.h
+++ b/include/xtd/math/sinh.h
@@ -1,21 +1,39 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
+
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float sinh(float arg) {
+  /* Computes the hyperbolic sine of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float sinh(float arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::sinhf(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::sinhf(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::sinh(arg);
+#else
+    // standard C/C++ code
+    return ::sinhf(arg);
+#endif
+  }
+
+  /* Computes the hyperbolic sine of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double sinh(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::sinh(arg);
@@ -26,34 +44,24 @@ namespace xtd {
     // SYCL device code
     return sycl::sinh(arg);
 #else
-    // standard C++ code
-    return std::sinh(arg);
+    // standard C/C++ code
+    return ::sinh(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr double sinh(double arg) {
-#if defined(XTD_TARGET_CUDA)
-    // CUDA device code
-    return ::sinh(arg);
-#elif defined(XTD_TARGET_HIP)
-    // HIP/ROCm device code
-    return ::sinh(arg);
-#elif defined(XTD_TARGET_SYCL)
-    // SYCL device code
-    return sycl::sinh(arg);
-#else
-    // standard C++ code
-    return std::sinh(arg);
-#endif
+  /* Computes the hyperbolic sine of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double sinh(std::integral auto arg) {
+    return xtd::sinh(static_cast<double>(arg));
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float sinhf(float arg) { return sinh(arg); }
-
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double sinh(T arg) {
-    return sinh(static_cast<double>(arg));
+  /* Computes the hyperbolic sine of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float sinhf(std::floating_point auto arg) {
+    return xtd::sinh(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float sinhf(std::integral auto arg) {
+    return xtd::sinh(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/sqrt.h
+++ b/include/xtd/math/sqrt.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float sqrt(float x) {
+  /* Computes the square root, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float sqrt(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::sqrt(x);
+    return ::sqrtf(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::sqrt(x);
+    return ::sqrtf(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::sqrt(x);
+    return sycl::sqrt(arg);
 #else
-    // standard C++ code
-    return std::sqrt(x);
+    // standard C/C++ code
+    return ::sqrtf(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double sqrt(double x) {
+  /* Computes the square root, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double sqrt(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::sqrt(x);
+    return ::sqrt(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::sqrt(x);
+    return ::sqrt(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::sqrt(x);
+    return sycl::sqrt(arg);
 #else
-    // standard C++ code
-    return std::sqrt(x);
+    // standard C/C++ code
+    return ::sqrt(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float sqrtf(float x) { return sqrt(x); }
+  /* Computes the square root, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double sqrt(std::integral auto arg) {
+    return xtd::sqrt(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double sqrt(T x) {
-    return sqrt(static_cast<double>(x));
+  /* Computes the square root, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float sqrtf(std::floating_point auto arg) {
+    return xtd::sqrt(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float sqrtf(std::integral auto arg) {
+    return xtd::sqrt(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/tan.h
+++ b/include/xtd/math/tan.h
@@ -1,22 +1,39 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float tan(float arg) {
+  /* Computes the tangent of arg (measured in radians), in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float tan(float arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::tanf(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::tanf(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::tan(arg);
+#else
+    // standard C/C++ code
+    return ::tanf(arg);
+#endif
+  }
+
+  /* Computes the tangent of arg (measured in radians), in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double tan(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::tan(arg);
@@ -27,34 +44,24 @@ namespace xtd {
     // SYCL device code
     return sycl::tan(arg);
 #else
-    // standard C++ code
-    return std::tan(arg);
+    // standard C/C++ code
+    return ::tan(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr double tan(double arg) {
-#if defined(XTD_TARGET_CUDA)
-    // CUDA device code
-    return ::tan(arg);
-#elif defined(XTD_TARGET_HIP)
-    // HIP/ROCm device code
-    return ::tan(arg);
-#elif defined(XTD_TARGET_SYCL)
-    // SYCL device code
-    return sycl::tan(arg);
-#else
-    // standard C++ code
-    return std::tan(arg);
-#endif
+  /* Computes the tangent of arg (measured in radians), in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double tan(std::integral auto arg) {
+    return xtd::tan(static_cast<double>(arg));
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float tanf(float arg) { return tan(arg); }
-
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double tan(T arg) {
-    return tan(static_cast<double>(arg));
+  /* Computes the tangent of arg (measured in radians), in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float tanf(std::floating_point auto arg) {
+    return xtd::tan(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float tanf(std::integral auto arg) {
+    return xtd::tan(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/tanh.h
+++ b/include/xtd/math/tanh.h
@@ -1,22 +1,39 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float tanh(float arg) {
+  /* Computes the hyperbolic tangent of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float tanh(float arg) {
+#if defined(XTD_TARGET_CUDA)
+    // CUDA device code
+    return ::tanhf(arg);
+#elif defined(XTD_TARGET_HIP)
+    // HIP/ROCm device code
+    return ::tanhf(arg);
+#elif defined(XTD_TARGET_SYCL)
+    // SYCL device code
+    return sycl::tanh(arg);
+#else
+    // standard C/C++ code
+    return ::tanhf(arg);
+#endif
+  }
+
+  /* Computes the hyperbolic tangent of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double tanh(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
     return ::tanh(arg);
@@ -27,34 +44,24 @@ namespace xtd {
     // SYCL device code
     return sycl::tanh(arg);
 #else
-    // stanhdard C++ code
-    return std::tanh(arg);
+    // standard C/C++ code
+    return ::tanh(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr double tanh(double arg) {
-#if defined(XTD_TARGET_CUDA)
-    // CUDA device code
-    return ::tanh(arg);
-#elif defined(XTD_TARGET_HIP)
-    // HIP/ROCm device code
-    return ::tanh(arg);
-#elif defined(XTD_TARGET_SYCL)
-    // SYCL device code
-    return sycl::tanh(arg);
-#else
-    // stanhdard C++ code
-    return std::tanh(arg);
-#endif
+  /* Computes the hyperbolic tangent of arg, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double tanh(std::integral auto arg) {
+    return xtd::tanh(static_cast<double>(arg));
   }
 
-  XTD_DEVICE_FUNCTION
-  inline constexpr float tanhf(float arg) { return tanh(arg); }
-
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double tanh(T arg) {
-    return tanh(static_cast<double>(arg));
+  /* Computes the hyperbolic tangent of arg, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float tanhf(std::floating_point auto arg) {
+    return xtd::tanh(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float tanhf(std::integral auto arg) {
+    return xtd::tanh(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/include/xtd/math/trunc.h
+++ b/include/xtd/math/trunc.h
@@ -1,57 +1,67 @@
 /*
  * Copyright 2025 European Organization for Nuclear Research (CERN)
- * Authors: Simone Balducci <simone.balducci@cern.ch>
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
-#include "xtd/internal/defines.h"
 #include <concepts>
-
-#if !defined(XTD_TARGET_CUDA) && !defined(XTD_TARGET_HIP) && !defined(XTD_TARGET_SYCL)
 #include <cmath>
-#endif
+
+#include "xtd/internal/defines.h"
 
 namespace xtd {
 
-  XTD_DEVICE_FUNCTION inline constexpr float trunc(float x) {
+  /* Computes the nearest integral value that is not larger than arg in magnitude, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float trunc(float arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::trunc(x);
+    return ::truncf(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::trunc(x);
+    return ::truncf(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::trunc(x);
+    return sycl::trunc(arg);
 #else
-    // standard C++ code
-    return std::trunc(x);
+    // standard C/C++ code
+    return ::truncf(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr double trunc(double x) {
+  /* Computes the nearest integral value that is not larger than arg in magnitude, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double trunc(double arg) {
 #if defined(XTD_TARGET_CUDA)
     // CUDA device code
-    return ::trunc(x);
+    return ::trunc(arg);
 #elif defined(XTD_TARGET_HIP)
     // HIP/ROCm device code
-    return ::trunc(x);
+    return ::trunc(arg);
 #elif defined(XTD_TARGET_SYCL)
     // SYCL device code
-    return sycl::trunc(x);
+    return sycl::trunc(arg);
 #else
-    // standard C++ code
-    return std::trunc(x);
+    // standard C/C++ code
+    return ::trunc(arg);
 #endif
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr float truncf(float x) { return trunc(x); }
+  /* Computes the nearest integral value that is not larger than arg in magnitude, in double precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double trunc(std::integral auto arg) {
+    return xtd::trunc(static_cast<double>(arg));
+  }
 
-  template <std::integral T>
-  XTD_DEVICE_FUNCTION inline constexpr double trunc(T x) {
-    return trunc(static_cast<double>(x));
+  /* Computes the nearest integral value that is not larger than arg in magnitude, in single precision.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float truncf(std::floating_point auto arg) {
+    return xtd::trunc(static_cast<float>(arg));
+  }
+  XTD_DEVICE_FUNCTION inline constexpr float truncf(std::integral auto arg) {
+    return xtd::trunc(static_cast<float>(arg));
   }
 
 }  // namespace xtd

--- a/test/cbrt/cbrt_t.cc
+++ b/test/cbrt/cbrt_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cbrt.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 4;
+
+TEST_CASE("xtd::cbrt", "[cbrt][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::cbrt(float)") {
+    test<float, float, xtd::cbrt, mpfr::cbrt>(values, ulps_float);
+  }
+
+  SECTION("double xtd::cbrt(double)") {
+    test<double, double, xtd::cbrt, mpfr::cbrt>(values, ulps_double);
+  }
+
+  SECTION("double xtd::cbrt(int)") {
+    test<double, int, xtd::cbrt, mpfr::cbrt>(values, ulps_double);
+  }
+
+  SECTION("float xtd::cbrtf(float)") {
+    test_f<float, float, xtd::cbrtf, mpfr::cbrt>(values, ulps_float);
+  }
+
+  SECTION("float xtd::cbrtf(double)") {
+    test_f<float, double, xtd::cbrtf, mpfr::cbrt>(values, ulps_float);
+  }
+
+  SECTION("float xtd::cbrtf(int)") {
+    test_f<float, int, xtd::cbrtf, mpfr::cbrt>(values, ulps_float);
+  }
+}

--- a/test/cbrt/cbrt_t.cu
+++ b/test/cbrt/cbrt_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cbrt.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cbrt", "[cbrt][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::cbrt(float)") {
+        test<float, float, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::cbrt(double)") {
+        test<double, double, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::cbrt(int)") {
+        test<double, int, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::cbrtf(float)") {
+        test_f<float, float, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::cbrtf(double)") {
+        test_f<float, double, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::cbrtf(int)") {
+        test_f<float, int, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/cbrt/cbrt_t.hip.cc
+++ b/test/cbrt/cbrt_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cbrt.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cbrt", "[cbrt][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::cbrt(float)") {
+        test<float, float, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::cbrt(double)") {
+        test<double, double, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::cbrt(int)") {
+        test<double, int, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::cbrtf(float)") {
+        test_f<float, float, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::cbrtf(double)") {
+        test_f<float, double, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::cbrtf(int)") {
+        test_f<float, int, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/cbrt/cbrt_t.sycl.cc
+++ b/test/cbrt/cbrt_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cbrt.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cbrt", "[cbrt][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::cbrt(float)") {
+              test<float, float, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::cbrt(double)") {
+              test<double, double, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::cbrt(int)") {
+              test<double, int, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::cbrtf(float)") {
+              test_f<float, float, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::cbrtf(double)") {
+              test_f<float, double, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::cbrtf(int)") {
+              test_f<float, int, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/ceil/ceil_t.cc
+++ b/test/ceil/ceil_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/ceil.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::ceil", "[ceil][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::ceil(float)") {
+    test<float, float, xtd::ceil, mpfr::ceil>(values, ulps_float);
+  }
+
+  SECTION("double xtd::ceil(double)") {
+    test<double, double, xtd::ceil, mpfr::ceil>(values, ulps_double);
+  }
+
+  SECTION("double xtd::ceil(int)") {
+    test<double, int, xtd::ceil, mpfr::ceil>(values, ulps_double);
+  }
+
+  SECTION("float xtd::ceilf(float)") {
+    test_f<float, float, xtd::ceilf, mpfr::ceil>(values, ulps_float);
+  }
+
+  SECTION("float xtd::ceilf(double)") {
+    test_f<float, double, xtd::ceilf, mpfr::ceil>(values, ulps_float);
+  }
+
+  SECTION("float xtd::ceilf(int)") {
+    test_f<float, int, xtd::ceilf, mpfr::ceil>(values, ulps_float);
+  }
+}

--- a/test/ceil/ceil_t.cu
+++ b/test/ceil/ceil_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/ceil.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::ceil", "[ceil][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::ceil(float)") {
+        test<float, float, xtd::ceil, mpfr::ceil>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::ceil(double)") {
+        test<double, double, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::ceil(int)") {
+        test<double, int, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::ceilf(float)") {
+        test_f<float, float, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::ceilf(double)") {
+        test_f<float, double, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::ceilf(int)") {
+        test_f<float, int, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/ceil/ceil_t.hip.cc
+++ b/test/ceil/ceil_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/ceil.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::ceil", "[ceil][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::ceil(float)") {
+        test<float, float, xtd::ceil, mpfr::ceil>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::ceil(double)") {
+        test<double, double, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::ceil(int)") {
+        test<double, int, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::ceilf(float)") {
+        test_f<float, float, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::ceilf(double)") {
+        test_f<float, double, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::ceilf(int)") {
+        test_f<float, int, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/ceil/ceil_t.sycl.cc
+++ b/test/ceil/ceil_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/ceil.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::ceil", "[ceil][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::ceil(float)") {
+              test<float, float, xtd::ceil, mpfr::ceil>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::ceil(double)") {
+              test<double, double, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::ceil(int)") {
+              test<double, int, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::ceilf(float)") {
+              test_f<float, float, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::ceilf(double)") {
+              test_f<float, double, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::ceilf(int)") {
+              test_f<float, int, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/cos/cos_t.cc
+++ b/test/cos/cos_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cos.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cos", "[cos][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::cos(float)") {
+    test<float, float, xtd::cos, mpfr::cos>(values, ulps_float);
+  }
+
+  SECTION("double xtd::cos(double)") {
+    test<double, double, xtd::cos, mpfr::cos>(values, ulps_double);
+  }
+
+  SECTION("double xtd::cos(int)") {
+    test<double, int, xtd::cos, mpfr::cos>(values, ulps_double);
+  }
+
+  SECTION("float xtd::cosf(float)") {
+    test_f<float, float, xtd::cosf, mpfr::cos>(values, ulps_float);
+  }
+
+  SECTION("float xtd::cosf(double)") {
+    test_f<float, double, xtd::cosf, mpfr::cos>(values, ulps_float);
+  }
+
+  SECTION("float xtd::cosf(int)") {
+    test_f<float, int, xtd::cosf, mpfr::cos>(values, ulps_float);
+  }
+}

--- a/test/cos/cos_t.cu
+++ b/test/cos/cos_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cos.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::cos", "[cos][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::cos(float)") {
+        test<float, float, xtd::cos, mpfr::cos>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::cos(double)") {
+        test<double, double, xtd::cos, mpfr::cos>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::cos(int)") {
+        test<double, int, xtd::cos, mpfr::cos>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::cosf(float)") {
+        test_f<float, float, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::cosf(double)") {
+        test_f<float, double, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::cosf(int)") {
+        test_f<float, int, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/cos/cos_t.hip.cc
+++ b/test/cos/cos_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cos.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cos", "[cos][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::cos(float)") {
+        test<float, float, xtd::cos, mpfr::cos>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::cos(double)") {
+        test<double, double, xtd::cos, mpfr::cos>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::cos(int)") {
+        test<double, int, xtd::cos, mpfr::cos>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::cosf(float)") {
+        test_f<float, float, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::cosf(double)") {
+        test_f<float, double, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::cosf(int)") {
+        test_f<float, int, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/cos/cos_t.sycl.cc
+++ b/test/cos/cos_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cos.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cos", "[cos][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::cos(float)") {
+              test<float, float, xtd::cos, mpfr::cos>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::cos(double)") {
+              test<double, double, xtd::cos, mpfr::cos>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::cos(int)") {
+              test<double, int, xtd::cos, mpfr::cos>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::cosf(float)") {
+              test_f<float, float, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::cosf(double)") {
+              test_f<float, double, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::cosf(int)") {
+              test_f<float, int, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/cosh/cosh_t.cc
+++ b/test/cosh/cosh_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cosh.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::cosh", "[cosh][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::cosh(float)") {
+    test<float, float, xtd::cosh, mpfr::cosh>(values, ulps_float);
+  }
+
+  SECTION("double xtd::cosh(double)") {
+    test<double, double, xtd::cosh, mpfr::cosh>(values, ulps_double);
+  }
+
+  SECTION("double xtd::cosh(int)") {
+    test<double, int, xtd::cosh, mpfr::cosh>(values, ulps_double);
+  }
+
+  SECTION("float xtd::coshf(float)") {
+    test_f<float, float, xtd::coshf, mpfr::cosh>(values, ulps_float);
+  }
+
+  SECTION("float xtd::coshf(double)") {
+    test_f<float, double, xtd::coshf, mpfr::cosh>(values, ulps_float);
+  }
+
+  SECTION("float xtd::coshf(int)") {
+    test_f<float, int, xtd::coshf, mpfr::cosh>(values, ulps_float);
+  }
+}

--- a/test/cosh/cosh_t.cu
+++ b/test/cosh/cosh_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cosh.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cosh", "[cosh][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::cosh(float)") {
+        test<float, float, xtd::cosh, mpfr::cosh>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::cosh(double)") {
+        test<double, double, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::cosh(int)") {
+        test<double, int, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::coshf(float)") {
+        test_f<float, float, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::coshf(double)") {
+        test_f<float, double, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::coshf(int)") {
+        test_f<float, int, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/cosh/cosh_t.hip.cc
+++ b/test/cosh/cosh_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cosh.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cosh", "[cosh][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::cosh(float)") {
+        test<float, float, xtd::cosh, mpfr::cosh>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::cosh(double)") {
+        test<double, double, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::cosh(int)") {
+        test<double, int, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::coshf(float)") {
+        test_f<float, float, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::coshf(double)") {
+        test_f<float, double, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::coshf(int)") {
+        test_f<float, int, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/cosh/cosh_t.sycl.cc
+++ b/test/cosh/cosh_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/cosh.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::cosh", "[cosh][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::cosh(float)") {
+              test<float, float, xtd::cosh, mpfr::cosh>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::cosh(double)") {
+              test<double, double, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::cosh(int)") {
+              test<double, int, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::coshf(float)") {
+              test_f<float, float, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::coshf(double)") {
+              test_f<float, double, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::coshf(int)") {
+              test_f<float, int, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/exp/exp_t.cc
+++ b/test/exp/exp_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/exp.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::exp", "[exp][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::exp(float)") {
+    test<float, float, xtd::exp, mpfr::exp>(values, ulps_float);
+  }
+
+  SECTION("double xtd::exp(double)") {
+    test<double, double, xtd::exp, mpfr::exp>(values, ulps_double);
+  }
+
+  SECTION("double xtd::exp(int)") {
+    test<double, int, xtd::exp, mpfr::exp>(values, ulps_double);
+  }
+
+  SECTION("float xtd::expf(float)") {
+    test_f<float, float, xtd::expf, mpfr::exp>(values, ulps_float);
+  }
+
+  SECTION("float xtd::expf(double)") {
+    test_f<float, double, xtd::expf, mpfr::exp>(values, ulps_float);
+  }
+
+  SECTION("float xtd::expf(int)") {
+    test_f<float, int, xtd::expf, mpfr::exp>(values, ulps_float);
+  }
+}

--- a/test/exp/exp_t.cu
+++ b/test/exp/exp_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/exp.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::exp", "[exp][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::exp(float)") {
+        test<float, float, xtd::exp, mpfr::exp>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::exp(double)") {
+        test<double, double, xtd::exp, mpfr::exp>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::exp(int)") {
+        test<double, int, xtd::exp, mpfr::exp>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::expf(float)") {
+        test_f<float, float, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::expf(double)") {
+        test_f<float, double, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::expf(int)") {
+        test_f<float, int, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/exp/exp_t.hip.cc
+++ b/test/exp/exp_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/exp.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::exp", "[exp][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::exp(float)") {
+        test<float, float, xtd::exp, mpfr::exp>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::exp(double)") {
+        test<double, double, xtd::exp, mpfr::exp>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::exp(int)") {
+        test<double, int, xtd::exp, mpfr::exp>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::expf(float)") {
+        test_f<float, float, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::expf(double)") {
+        test_f<float, double, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::expf(int)") {
+        test_f<float, int, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/exp/exp_t.sycl.cc
+++ b/test/exp/exp_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/exp.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::exp", "[exp][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::exp(float)") {
+              test<float, float, xtd::exp, mpfr::exp>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::exp(double)") {
+              test<double, double, xtd::exp, mpfr::exp>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::exp(int)") {
+              test<double, int, xtd::exp, mpfr::exp>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::expf(float)") {
+              test_f<float, float, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::expf(double)") {
+              test_f<float, double, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::expf(int)") {
+              test_f<float, int, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/exp2/exp2_t.cc
+++ b/test/exp2/exp2_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/exp2.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::exp2", "[exp2][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::exp2(float)") {
+    test<float, float, xtd::exp2, mpfr::exp2>(values, ulps_float);
+  }
+
+  SECTION("double xtd::exp2(double)") {
+    test<double, double, xtd::exp2, mpfr::exp2>(values, ulps_double);
+  }
+
+  SECTION("double xtd::exp2(int)") {
+    test<double, int, xtd::exp2, mpfr::exp2>(values, ulps_double);
+  }
+
+  SECTION("float xtd::exp2f(float)") {
+    test_f<float, float, xtd::exp2f, mpfr::exp2>(values, ulps_float);
+  }
+
+  SECTION("float xtd::exp2f(double)") {
+    test_f<float, double, xtd::exp2f, mpfr::exp2>(values, ulps_float);
+  }
+
+  SECTION("float xtd::exp2f(int)") {
+    test_f<float, int, xtd::exp2f, mpfr::exp2>(values, ulps_float);
+  }
+}

--- a/test/exp2/exp2_t.cu
+++ b/test/exp2/exp2_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/exp2.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::exp2", "[exp2][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::exp2(float)") {
+        test<float, float, xtd::exp2, mpfr::exp2>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::exp2(double)") {
+        test<double, double, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::exp2(int)") {
+        test<double, int, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::exp2f(float)") {
+        test_f<float, float, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::exp2f(double)") {
+        test_f<float, double, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::exp2f(int)") {
+        test_f<float, int, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/exp2/exp2_t.hip.cc
+++ b/test/exp2/exp2_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/exp2.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::exp2", "[exp2][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::exp2(float)") {
+        test<float, float, xtd::exp2, mpfr::exp2>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::exp2(double)") {
+        test<double, double, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::exp2(int)") {
+        test<double, int, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::exp2f(float)") {
+        test_f<float, float, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::exp2f(double)") {
+        test_f<float, double, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::exp2f(int)") {
+        test_f<float, int, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/exp2/exp2_t.sycl.cc
+++ b/test/exp2/exp2_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/exp2.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::exp2", "[exp2][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::exp2(float)") {
+              test<float, float, xtd::exp2, mpfr::exp2>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::exp2(double)") {
+              test<double, double, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::exp2(int)") {
+              test<double, int, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::exp2f(float)") {
+              test_f<float, float, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::exp2f(double)") {
+              test_f<float, double, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::exp2f(int)") {
+              test_f<float, int, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/expm1/expm1_t.cc
+++ b/test/expm1/expm1_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/expm1.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::expm1", "[expm1][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::expm1(float)") {
+    test<float, float, xtd::expm1, mpfr::expm1>(values, ulps_float);
+  }
+
+  SECTION("double xtd::expm1(double)") {
+    test<double, double, xtd::expm1, mpfr::expm1>(values, ulps_double);
+  }
+
+  SECTION("double xtd::expm1(int)") {
+    test<double, int, xtd::expm1, mpfr::expm1>(values, ulps_double);
+  }
+
+  SECTION("float xtd::expm1f(float)") {
+    test_f<float, float, xtd::expm1f, mpfr::expm1>(values, ulps_float);
+  }
+
+  SECTION("float xtd::expm1f(double)") {
+    test_f<float, double, xtd::expm1f, mpfr::expm1>(values, ulps_float);
+  }
+
+  SECTION("float xtd::expm1f(int)") {
+    test_f<float, int, xtd::expm1f, mpfr::expm1>(values, ulps_float);
+  }
+}

--- a/test/expm1/expm1_t.cu
+++ b/test/expm1/expm1_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/expm1.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::expm1", "[expm1][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::expm1(float)") {
+        test<float, float, xtd::expm1, mpfr::expm1>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::expm1(double)") {
+        test<double, double, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::expm1(int)") {
+        test<double, int, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::expm1f(float)") {
+        test_f<float, float, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::expm1f(double)") {
+        test_f<float, double, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::expm1f(int)") {
+        test_f<float, int, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/expm1/expm1_t.hip.cc
+++ b/test/expm1/expm1_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/expm1.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 2;  // 1 ULP for x ∈ [-10., +10.] according to the documentation
+
+TEST_CASE("xtd::expm1", "[expm1][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::expm1(float)") {
+        test<float, float, xtd::expm1, mpfr::expm1>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::expm1(double)") {
+        test<double, double, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::expm1(int)") {
+        test<double, int, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::expm1f(float)") {
+        test_f<float, float, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::expm1f(double)") {
+        test_f<float, double, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::expm1f(int)") {
+        test_f<float, int, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/expm1/expm1_t.sycl.cc
+++ b/test/expm1/expm1_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/expm1.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::expm1", "[expm1][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::expm1(float)") {
+              test<float, float, xtd::expm1, mpfr::expm1>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::expm1(double)") {
+              test<double, double, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::expm1(int)") {
+              test<double, int, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::expm1f(float)") {
+              test_f<float, float, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::expm1f(double)") {
+              test_f<float, double, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::expm1f(int)") {
+              test_f<float, int, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/floor/floor_t.cc
+++ b/test/floor/floor_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/floor.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::floor", "[floor][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::floor(float)") {
+    test<float, float, xtd::floor, mpfr::floor>(values, ulps_float);
+  }
+
+  SECTION("double xtd::floor(double)") {
+    test<double, double, xtd::floor, mpfr::floor>(values, ulps_double);
+  }
+
+  SECTION("double xtd::floor(int)") {
+    test<double, int, xtd::floor, mpfr::floor>(values, ulps_double);
+  }
+
+  SECTION("float xtd::floorf(float)") {
+    test_f<float, float, xtd::floorf, mpfr::floor>(values, ulps_float);
+  }
+
+  SECTION("float xtd::floorf(double)") {
+    test_f<float, double, xtd::floorf, mpfr::floor>(values, ulps_float);
+  }
+
+  SECTION("float xtd::floorf(int)") {
+    test_f<float, int, xtd::floorf, mpfr::floor>(values, ulps_float);
+  }
+}

--- a/test/floor/floor_t.cu
+++ b/test/floor/floor_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/floor.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::floor", "[floor][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::floor(float)") {
+        test<float, float, xtd::floor, mpfr::floor>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::floor(double)") {
+        test<double, double, xtd::floor, mpfr::floor>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::floor(int)") {
+        test<double, int, xtd::floor, mpfr::floor>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::floorf(float)") {
+        test_f<float, float, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::floorf(double)") {
+        test_f<float, double, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::floorf(int)") {
+        test_f<float, int, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/floor/floor_t.hip.cc
+++ b/test/floor/floor_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/floor.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::floor", "[floor][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::floor(float)") {
+        test<float, float, xtd::floor, mpfr::floor>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::floor(double)") {
+        test<double, double, xtd::floor, mpfr::floor>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::floor(int)") {
+        test<double, int, xtd::floor, mpfr::floor>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::floorf(float)") {
+        test_f<float, float, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::floorf(double)") {
+        test_f<float, double, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::floorf(int)") {
+        test_f<float, int, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/floor/floor_t.sycl.cc
+++ b/test/floor/floor_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/floor.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::floor", "[floor][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::floor(float)") {
+              test<float, float, xtd::floor, mpfr::floor>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::floor(double)") {
+              test<double, double, xtd::floor, mpfr::floor>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::floor(int)") {
+              test<double, int, xtd::floor, mpfr::floor>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::floorf(float)") {
+              test_f<float, float, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::floorf(double)") {
+              test_f<float, double, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::floorf(int)") {
+              test_f<float, int, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/log/log_t.cc
+++ b/test/log/log_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log", "[log][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::log(float)") {
+    test<float, float, xtd::log, mpfr::log>(values, ulps_float);
+  }
+
+  SECTION("double xtd::log(double)") {
+    test<double, double, xtd::log, mpfr::log>(values, ulps_double);
+  }
+
+  SECTION("double xtd::log(int)") {
+    test<double, int, xtd::log, mpfr::log>(values, ulps_double);
+  }
+
+  SECTION("float xtd::logf(float)") {
+    test_f<float, float, xtd::logf, mpfr::log>(values, ulps_float);
+  }
+
+  SECTION("float xtd::logf(double)") {
+    test_f<float, double, xtd::logf, mpfr::log>(values, ulps_float);
+  }
+
+  SECTION("float xtd::logf(int)") {
+    test_f<float, int, xtd::logf, mpfr::log>(values, ulps_float);
+  }
+}

--- a/test/log/log_t.cu
+++ b/test/log/log_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log", "[log][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::log(float)") {
+        test<float, float, xtd::log, mpfr::log>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::log(double)") {
+        test<double, double, xtd::log, mpfr::log>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::log(int)") {
+        test<double, int, xtd::log, mpfr::log>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::logf(float)") {
+        test_f<float, float, xtd::logf, mpfr::log>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::logf(double)") {
+        test_f<float, double, xtd::logf, mpfr::log>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::logf(int)") {
+        test_f<float, int, xtd::logf, mpfr::log>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/log/log_t.hip.cc
+++ b/test/log/log_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log", "[log][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::log(float)") {
+        test<float, float, xtd::log, mpfr::log>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::log(double)") {
+        test<double, double, xtd::log, mpfr::log>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::log(int)") {
+        test<double, int, xtd::log, mpfr::log>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::logf(float)") {
+        test_f<float, float, xtd::logf, mpfr::log>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::logf(double)") {
+        test_f<float, double, xtd::logf, mpfr::log>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::logf(int)") {
+        test_f<float, int, xtd::logf, mpfr::log>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/log/log_t.sycl.cc
+++ b/test/log/log_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log", "[log][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::log(float)") {
+              test<float, float, xtd::log, mpfr::log>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::log(double)") {
+              test<double, double, xtd::log, mpfr::log>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::log(int)") {
+              test<double, int, xtd::log, mpfr::log>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::logf(float)") {
+              test_f<float, float, xtd::logf, mpfr::log>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::logf(double)") {
+              test_f<float, double, xtd::logf, mpfr::log>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::logf(int)") {
+              test_f<float, int, xtd::logf, mpfr::log>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/log10/log10_t.cc
+++ b/test/log10/log10_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log10.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::log10", "[log10][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::log10(float)") {
+    test<float, float, xtd::log10, mpfr::log10>(values, ulps_float);
+  }
+
+  SECTION("double xtd::log10(double)") {
+    test<double, double, xtd::log10, mpfr::log10>(values, ulps_double);
+  }
+
+  SECTION("double xtd::log10(int)") {
+    test<double, int, xtd::log10, mpfr::log10>(values, ulps_double);
+  }
+
+  SECTION("float xtd::log10f(float)") {
+    test_f<float, float, xtd::log10f, mpfr::log10>(values, ulps_float);
+  }
+
+  SECTION("float xtd::log10f(double)") {
+    test_f<float, double, xtd::log10f, mpfr::log10>(values, ulps_float);
+  }
+
+  SECTION("float xtd::log10f(int)") {
+    test_f<float, int, xtd::log10f, mpfr::log10>(values, ulps_float);
+  }
+}

--- a/test/log10/log10_t.cu
+++ b/test/log10/log10_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log10.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log10", "[log10][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::log10(float)") {
+        test<float, float, xtd::log10, mpfr::log10>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::log10(double)") {
+        test<double, double, xtd::log10, mpfr::log10>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::log10(int)") {
+        test<double, int, xtd::log10, mpfr::log10>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::log10f(float)") {
+        test_f<float, float, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log10f(double)") {
+        test_f<float, double, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log10f(int)") {
+        test_f<float, int, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/log10/log10_t.hip.cc
+++ b/test/log10/log10_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log10.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log10", "[log10][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::log10(float)") {
+        test<float, float, xtd::log10, mpfr::log10>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::log10(double)") {
+        test<double, double, xtd::log10, mpfr::log10>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::log10(int)") {
+        test<double, int, xtd::log10, mpfr::log10>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::log10f(float)") {
+        test_f<float, float, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log10f(double)") {
+        test_f<float, double, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log10f(int)") {
+        test_f<float, int, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/log10/log10_t.sycl.cc
+++ b/test/log10/log10_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log10.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log10", "[log10][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::log10(float)") {
+              test<float, float, xtd::log10, mpfr::log10>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::log10(double)") {
+              test<double, double, xtd::log10, mpfr::log10>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::log10(int)") {
+              test<double, int, xtd::log10, mpfr::log10>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::log10f(float)") {
+              test_f<float, float, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::log10f(double)") {
+              test_f<float, double, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::log10f(int)") {
+              test_f<float, int, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/log1p/log1p_t.cc
+++ b/test/log1p/log1p_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log1p.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log1p", "[log1p][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::log1p(float)") {
+    test<float, float, xtd::log1p, mpfr::log1p>(values, ulps_float);
+  }
+
+  SECTION("double xtd::log1p(double)") {
+    test<double, double, xtd::log1p, mpfr::log1p>(values, ulps_double);
+  }
+
+  SECTION("double xtd::log1p(int)") {
+    test<double, int, xtd::log1p, mpfr::log1p>(values, ulps_double);
+  }
+
+  SECTION("float xtd::log1pf(float)") {
+    test_f<float, float, xtd::log1pf, mpfr::log1p>(values, ulps_float);
+  }
+
+  SECTION("float xtd::log1pf(double)") {
+    test_f<float, double, xtd::log1pf, mpfr::log1p>(values, ulps_float);
+  }
+
+  SECTION("float xtd::log1pf(int)") {
+    test_f<float, int, xtd::log1pf, mpfr::log1p>(values, ulps_float);
+  }
+}

--- a/test/log1p/log1p_t.cu
+++ b/test/log1p/log1p_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log1p.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log1p", "[log1p][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::log1p(float)") {
+        test<float, float, xtd::log1p, mpfr::log1p>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::log1p(double)") {
+        test<double, double, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::log1p(int)") {
+        test<double, int, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::log1pf(float)") {
+        test_f<float, float, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log1pf(double)") {
+        test_f<float, double, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log1pf(int)") {
+        test_f<float, int, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/log1p/log1p_t.hip.cc
+++ b/test/log1p/log1p_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log1p.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log1p", "[log1p][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::log1p(float)") {
+        test<float, float, xtd::log1p, mpfr::log1p>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::log1p(double)") {
+        test<double, double, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::log1p(int)") {
+        test<double, int, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::log1pf(float)") {
+        test_f<float, float, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log1pf(double)") {
+        test_f<float, double, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log1pf(int)") {
+        test_f<float, int, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/log1p/log1p_t.sycl.cc
+++ b/test/log1p/log1p_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log1p.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log1p", "[log1p][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::log1p(float)") {
+              test<float, float, xtd::log1p, mpfr::log1p>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::log1p(double)") {
+              test<double, double, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::log1p(int)") {
+              test<double, int, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::log1pf(float)") {
+              test_f<float, float, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::log1pf(double)") {
+              test_f<float, double, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::log1pf(int)") {
+              test_f<float, int, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/log2/log2_t.cc
+++ b/test/log2/log2_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log2.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::log2", "[log2][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::log2(float)") {
+    test<float, float, xtd::log2, mpfr::log2>(values, ulps_float);
+  }
+
+  SECTION("double xtd::log2(double)") {
+    test<double, double, xtd::log2, mpfr::log2>(values, ulps_double);
+  }
+
+  SECTION("double xtd::log2(int)") {
+    test<double, int, xtd::log2, mpfr::log2>(values, ulps_double);
+  }
+
+  SECTION("float xtd::log2f(float)") {
+    test_f<float, float, xtd::log2f, mpfr::log2>(values, ulps_float);
+  }
+
+  SECTION("float xtd::log2f(double)") {
+    test_f<float, double, xtd::log2f, mpfr::log2>(values, ulps_float);
+  }
+
+  SECTION("float xtd::log2f(int)") {
+    test_f<float, int, xtd::log2f, mpfr::log2>(values, ulps_float);
+  }
+}

--- a/test/log2/log2_t.cu
+++ b/test/log2/log2_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log2.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log2", "[log2][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::log2(float)") {
+        test<float, float, xtd::log2, mpfr::log2>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::log2(double)") {
+        test<double, double, xtd::log2, mpfr::log2>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::log2(int)") {
+        test<double, int, xtd::log2, mpfr::log2>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::log2f(float)") {
+        test_f<float, float, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log2f(double)") {
+        test_f<float, double, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log2f(int)") {
+        test_f<float, int, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/log2/log2_t.hip.cc
+++ b/test/log2/log2_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log2.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log2", "[log2][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::log2(float)") {
+        test<float, float, xtd::log2, mpfr::log2>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::log2(double)") {
+        test<double, double, xtd::log2, mpfr::log2>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::log2(int)") {
+        test<double, int, xtd::log2, mpfr::log2>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::log2f(float)") {
+        test_f<float, float, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log2f(double)") {
+        test_f<float, double, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::log2f(int)") {
+        test_f<float, int, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/log2/log2_t.sycl.cc
+++ b/test/log2/log2_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/log2.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::log2", "[log2][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::log2(float)") {
+              test<float, float, xtd::log2, mpfr::log2>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::log2(double)") {
+              test<double, double, xtd::log2, mpfr::log2>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::log2(int)") {
+              test<double, int, xtd::log2, mpfr::log2>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::log2f(float)") {
+              test_f<float, float, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::log2f(double)") {
+              test_f<float, double, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::log2f(int)") {
+              test_f<float, int, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/sinh/sinh_t.cc
+++ b/test/sinh/sinh_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/sinh.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::sinh", "[sinh][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::sinh(float)") {
+    test<float, float, xtd::sinh, mpfr::sinh>(values, ulps_float);
+  }
+
+  SECTION("double xtd::sinh(double)") {
+    test<double, double, xtd::sinh, mpfr::sinh>(values, ulps_double);
+  }
+
+  SECTION("double xtd::sinh(int)") {
+    test<double, int, xtd::sinh, mpfr::sinh>(values, ulps_double);
+  }
+
+  SECTION("float xtd::sinhf(float)") {
+    test_f<float, float, xtd::sinhf, mpfr::sinh>(values, ulps_float);
+  }
+
+  SECTION("float xtd::sinhf(double)") {
+    test_f<float, double, xtd::sinhf, mpfr::sinh>(values, ulps_float);
+  }
+
+  SECTION("float xtd::sinhf(int)") {
+    test_f<float, int, xtd::sinhf, mpfr::sinh>(values, ulps_float);
+  }
+}

--- a/test/sinh/sinh_t.cu
+++ b/test/sinh/sinh_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/sinh.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 3;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::sinh", "[sinh][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::sinh(float)") {
+        test<float, float, xtd::sinh, mpfr::sinh>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::sinh(double)") {
+        test<double, double, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::sinh(int)") {
+        test<double, int, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::sinhf(float)") {
+        test_f<float, float, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::sinhf(double)") {
+        test_f<float, double, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::sinhf(int)") {
+        test_f<float, int, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/sinh/sinh_t.hip.cc
+++ b/test/sinh/sinh_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/sinh.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::sinh", "[sinh][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::sinh(float)") {
+        test<float, float, xtd::sinh, mpfr::sinh>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::sinh(double)") {
+        test<double, double, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::sinh(int)") {
+        test<double, int, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::sinhf(float)") {
+        test_f<float, float, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::sinhf(double)") {
+        test_f<float, double, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::sinhf(int)") {
+        test_f<float, int, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/sinh/sinh_t.sycl.cc
+++ b/test/sinh/sinh_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/sinh.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::sinh", "[sinh][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::sinh(float)") {
+              test<float, float, xtd::sinh, mpfr::sinh>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::sinh(double)") {
+              test<double, double, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::sinh(int)") {
+              test<double, int, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::sinhf(float)") {
+              test_f<float, float, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::sinhf(double)") {
+              test_f<float, double, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::sinhf(int)") {
+              test_f<float, int, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/sqrt/sqrt_t.cc
+++ b/test/sqrt/sqrt_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/sqrt.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::sqrt", "[sqrt][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::sqrt(float)") {
+    test<float, float, xtd::sqrt, mpfr::sqrt>(values, ulps_float);
+  }
+
+  SECTION("double xtd::sqrt(double)") {
+    test<double, double, xtd::sqrt, mpfr::sqrt>(values, ulps_double);
+  }
+
+  SECTION("double xtd::sqrt(int)") {
+    test<double, int, xtd::sqrt, mpfr::sqrt>(values, ulps_double);
+  }
+
+  SECTION("float xtd::sqrtf(float)") {
+    test_f<float, float, xtd::sqrtf, mpfr::sqrt>(values, ulps_float);
+  }
+
+  SECTION("float xtd::sqrtf(double)") {
+    test_f<float, double, xtd::sqrtf, mpfr::sqrt>(values, ulps_float);
+  }
+
+  SECTION("float xtd::sqrtf(int)") {
+    test_f<float, int, xtd::sqrtf, mpfr::sqrt>(values, ulps_float);
+  }
+}

--- a/test/sqrt/sqrt_t.cu
+++ b/test/sqrt/sqrt_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/sqrt.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::sqrt", "[sqrt][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::sqrt(float)") {
+        test<float, float, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::sqrt(double)") {
+        test<double, double, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::sqrt(int)") {
+        test<double, int, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::sqrtf(float)") {
+        test_f<float, float, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::sqrtf(double)") {
+        test_f<float, double, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::sqrtf(int)") {
+        test_f<float, int, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/sqrt/sqrt_t.hip.cc
+++ b/test/sqrt/sqrt_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/sqrt.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::sqrt", "[sqrt][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::sqrt(float)") {
+        test<float, float, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::sqrt(double)") {
+        test<double, double, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::sqrt(int)") {
+        test<double, int, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::sqrtf(float)") {
+        test_f<float, float, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::sqrtf(double)") {
+        test_f<float, double, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::sqrtf(int)") {
+        test_f<float, int, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/sqrt/sqrt_t.sycl.cc
+++ b/test/sqrt/sqrt_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/sqrt.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 3;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::sqrt", "[sqrt][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::sqrt(float)") {
+              test<float, float, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::sqrt(double)") {
+              test<double, double, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::sqrt(int)") {
+              test<double, int, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::sqrtf(float)") {
+              test_f<float, float, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::sqrtf(double)") {
+              test_f<float, double, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::sqrtf(int)") {
+              test_f<float, int, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/tan/tan_t.cc
+++ b/test/tan/tan_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/tan.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::tan", "[tan][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::tan(float)") {
+    test<float, float, xtd::tan, mpfr::tan>(values, ulps_float);
+  }
+
+  SECTION("double xtd::tan(double)") {
+    test<double, double, xtd::tan, mpfr::tan>(values, ulps_double);
+  }
+
+  SECTION("double xtd::tan(int)") {
+    test<double, int, xtd::tan, mpfr::tan>(values, ulps_double);
+  }
+
+  SECTION("float xtd::tanf(float)") {
+    test_f<float, float, xtd::tanf, mpfr::tan>(values, ulps_float);
+  }
+
+  SECTION("float xtd::tanf(double)") {
+    test_f<float, double, xtd::tanf, mpfr::tan>(values, ulps_float);
+  }
+
+  SECTION("float xtd::tanf(int)") {
+    test_f<float, int, xtd::tanf, mpfr::tan>(values, ulps_float);
+  }
+}

--- a/test/tan/tan_t.cu
+++ b/test/tan/tan_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/tan.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::tan", "[tan][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::tan(float)") {
+        test<float, float, xtd::tan, mpfr::tan>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::tan(double)") {
+        test<double, double, xtd::tan, mpfr::tan>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::tan(int)") {
+        test<double, int, xtd::tan, mpfr::tan>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::tanf(float)") {
+        test_f<float, float, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::tanf(double)") {
+        test_f<float, double, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::tanf(int)") {
+        test_f<float, int, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/tan/tan_t.hip.cc
+++ b/test/tan/tan_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/tan.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;   // 1 ULP for x ∈ [-1.47 π, +1.47 π] according to the documentation
+constexpr int ulps_double = 2;  // 1 ULP for x ∈ [-1.47 π, +1.47 π] according to the documentation
+
+TEST_CASE("xtd::tan", "[tan][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::tan(float)") {
+        test<float, float, xtd::tan, mpfr::tan>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::tan(double)") {
+        test<double, double, xtd::tan, mpfr::tan>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::tan(int)") {
+        test<double, int, xtd::tan, mpfr::tan>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::tanf(float)") {
+        test_f<float, float, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::tanf(double)") {
+        test_f<float, double, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::tanf(int)") {
+        test_f<float, int, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/tan/tan_t.sycl.cc
+++ b/test/tan/tan_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/tan.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::tan", "[tan][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::tan(float)") {
+              test<float, float, xtd::tan, mpfr::tan>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::tan(double)") {
+              test<double, double, xtd::tan, mpfr::tan>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::tan(int)") {
+              test<double, int, xtd::tan, mpfr::tan>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::tanf(float)") {
+              test_f<float, float, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::tanf(double)") {
+              test_f<float, double, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::tanf(int)") {
+              test_f<float, int, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/tanh/tanh_t.cc
+++ b/test/tanh/tanh_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/tanh.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 2;
+
+TEST_CASE("xtd::tanh", "[tanh][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::tanh(float)") {
+    test<float, float, xtd::tanh, mpfr::tanh>(values, ulps_float);
+  }
+
+  SECTION("double xtd::tanh(double)") {
+    test<double, double, xtd::tanh, mpfr::tanh>(values, ulps_double);
+  }
+
+  SECTION("double xtd::tanh(int)") {
+    test<double, int, xtd::tanh, mpfr::tanh>(values, ulps_double);
+  }
+
+  SECTION("float xtd::tanhf(float)") {
+    test_f<float, float, xtd::tanhf, mpfr::tanh>(values, ulps_float);
+  }
+
+  SECTION("float xtd::tanhf(double)") {
+    test_f<float, double, xtd::tanhf, mpfr::tanh>(values, ulps_float);
+  }
+
+  SECTION("float xtd::tanhf(int)") {
+    test_f<float, int, xtd::tanhf, mpfr::tanh>(values, ulps_float);
+  }
+}

--- a/test/tanh/tanh_t.cu
+++ b/test/tanh/tanh_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/tanh.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::tanh", "[tanh][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::tanh(float)") {
+        test<float, float, xtd::tanh, mpfr::tanh>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::tanh(double)") {
+        test<double, double, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::tanh(int)") {
+        test<double, int, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::tanhf(float)") {
+        test_f<float, float, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::tanhf(double)") {
+        test_f<float, double, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::tanhf(int)") {
+        test_f<float, int, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/tanh/tanh_t.hip.cc
+++ b/test/tanh/tanh_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/tanh.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::tanh", "[tanh][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::tanh(float)") {
+        test<float, float, xtd::tanh, mpfr::tanh>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::tanh(double)") {
+        test<double, double, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::tanh(int)") {
+        test<double, int, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::tanhf(float)") {
+        test_f<float, float, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::tanhf(double)") {
+        test_f<float, double, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::tanhf(int)") {
+        test_f<float, int, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/tanh/tanh_t.sycl.cc
+++ b/test/tanh/tanh_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/tanh.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 1;
+constexpr int ulps_double = 1;
+
+TEST_CASE("xtd::tanh", "[tanh][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::tanh(float)") {
+              test<float, float, xtd::tanh, mpfr::tanh>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::tanh(double)") {
+              test<double, double, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::tanh(int)") {
+              test<double, int, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::tanhf(float)") {
+              test_f<float, float, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::tanhf(double)") {
+              test_f<float, double, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::tanhf(int)") {
+              test_f<float, int, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/trunc/trunc_t.cc
+++ b/test/trunc/trunc_t.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/trunc.h"
+
+// test headers
+#include "common/cpu_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::trunc", "[trunc][cpu]") {
+  std::vector<double> values = generate_input_values();
+
+  SECTION("float xtd::trunc(float)") {
+    test<float, float, xtd::trunc, mpfr::trunc>(values, ulps_float);
+  }
+
+  SECTION("double xtd::trunc(double)") {
+    test<double, double, xtd::trunc, mpfr::trunc>(values, ulps_double);
+  }
+
+  SECTION("double xtd::trunc(int)") {
+    test<double, int, xtd::trunc, mpfr::trunc>(values, ulps_double);
+  }
+
+  SECTION("float xtd::truncf(float)") {
+    test_f<float, float, xtd::truncf, mpfr::trunc>(values, ulps_float);
+  }
+
+  SECTION("float xtd::truncf(double)") {
+    test_f<float, double, xtd::truncf, mpfr::trunc>(values, ulps_float);
+  }
+
+  SECTION("float xtd::truncf(int)") {
+    test_f<float, int, xtd::truncf, mpfr::trunc>(values, ulps_float);
+  }
+}

--- a/test/trunc/trunc_t.cu
+++ b/test/trunc/trunc_t.cu
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/trunc.h"
+
+// test headers
+#include "common/cuda_check.h"
+#include "common/cuda_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::trunc", "[trunc][cuda]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  cudaError_t cudaStatus = cudaGetDeviceCount(&deviceCount);
+
+  if (cudaStatus != cudaSuccess || deviceCount == 0) {
+    std::cout << "No NVIDIA GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    cudaDeviceProp properties;
+    CUDA_CHECK(cudaGetDeviceProperties(&properties, device));
+    std::string section = "CUDA GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      CUDA_CHECK(cudaSetDevice(device));
+
+      // create a CUDA stream for all the asynchronous operations on this GPU
+      cudaStream_t queue;
+      CUDA_CHECK(cudaStreamCreate(&queue));
+
+      SECTION("float xtd::trunc(float)") {
+        test<float, float, xtd::trunc, mpfr::trunc>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::trunc(double)") {
+        test<double, double, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::trunc(int)") {
+        test<double, int, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::truncf(float)") {
+        test_f<float, float, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::truncf(double)") {
+        test_f<float, double, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::truncf(int)") {
+        test_f<float, int, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+      }
+
+      CUDA_CHECK(cudaStreamDestroy(queue));
+    }
+  }
+}

--- a/test/trunc/trunc_t.hip.cc
+++ b/test/trunc/trunc_t.hip.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std::literals;
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/trunc.h"
+
+// test headers
+#include "common/hip_check.h"
+#include "common/hip_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::trunc", "[trunc][hip]") {
+  std::vector<double> values = generate_input_values();
+
+  int deviceCount;
+  hipError_t hipStatus = hipGetDeviceCount(&deviceCount);
+
+  if (hipStatus != hipSuccess || deviceCount == 0) {
+    std::cout << "No AMD GPUs found, the test will be skipped.\n\n";
+    exit(EXIT_SUCCESS);
+  }
+
+  for (int device = 0; device < deviceCount; ++device) {
+    hipDeviceProp_t properties;
+    HIP_CHECK(hipGetDeviceProperties(&properties, device));
+    std::string section = "HIP GPU "s + std::to_string(device) + ": "s + properties.name;
+    SECTION(section) {
+      // set the current GPU
+      HIP_CHECK(hipSetDevice(device));
+
+      // create a HIP stream for all the asynchronous operations on this GPU
+      hipStream_t queue;
+      HIP_CHECK(hipStreamCreate(&queue));
+
+      SECTION("float xtd::trunc(float)") {
+        test<float, float, xtd::trunc, mpfr::trunc>(queue, values, ulps_float);
+      }
+
+      SECTION("double xtd::trunc(double)") {
+        test<double, double, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
+      }
+
+      SECTION("double xtd::trunc(int)") {
+        test<double, int, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
+      }
+
+      SECTION("float xtd::truncf(float)") {
+        test_f<float, float, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::truncf(double)") {
+        test_f<float, double, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+      }
+
+      SECTION("float xtd::truncf(int)") {
+        test_f<float, int, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+      }
+
+      HIP_CHECK(hipStreamDestroy(queue));
+    }
+  }
+}

--- a/test/trunc/trunc_t.sycl.cc
+++ b/test/trunc/trunc_t.sycl.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Catch2 headers
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// mpfr::real headers
+#include <real.hpp>
+
+// xtd headers
+#include "xtd/math/trunc.h"
+
+// test headers
+#include "common/sycl_test.h"
+#include "common/math_inputs.h"
+
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::trunc", "[trunc][sycl]") {
+  std::vector<double> values = generate_input_values();
+
+  for (const auto &platform : sycl::platform::get_platforms()) {
+    SECTION(platform.get_info<sycl::info::platform::name>()) {
+      for (const auto &device : platform.get_devices()) {
+        SECTION(device.get_info<sycl::info::device::name>()) {
+          try {
+            sycl::queue queue{device, sycl::property::queue::in_order()};
+
+            SECTION("float xtd::trunc(float)") {
+              test<float, float, xtd::trunc, mpfr::trunc>(queue, values, ulps_float);
+            }
+
+            SECTION("double xtd::trunc(double)") {
+              test<double, double, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
+            }
+
+            SECTION("double xtd::trunc(int)") {
+              test<double, int, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
+            }
+
+            SECTION("float xtd::truncf(float)") {
+              test_f<float, float, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::truncf(double)") {
+              test_f<float, double, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+            }
+
+            SECTION("float xtd::truncf(int)") {
+              test_f<float, int, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+            }
+
+          } catch (sycl::exception const &e) {
+            std::cerr << "SYCL exception:\n"
+                      << e.what() << "\ncaught while running on platform "
+                      << platform.get_info<sycl::info::platform::name>() << ", device "
+                      << device.get_info<sycl::info::device::name>() << '\n';
+            continue;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Reimplement the `xtd` functions `cbrt`, `ceil`, `cos`, `cosh`, `exp`, `exp2`, `expm1`, `floor`, `log`, `log10`, `log1p`, `log2`, `sinh`, `sqrt`, `tan`, `tanh`, `trunc`, and add their unit tests.