### PR TITLE
Update SYCL tests with accuracy from OpenCL spec, and skip fp64 tests on unsupported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,53 +177,59 @@ Note: in some cases the accuracy is documented only for a small range of values.
 
 ### Intel oneAPI
 
-The accuracy of the Intel oneAPI math functions implementation is described in
-https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2025-2/imf-transcendental-math-functions.html
-and summarised below for the default accuracy:
+The SYCL specification does not describe the accuracy of the mathematical functions.
+Since the SYCL programming model was originally designed as a high-level model for
+the OpenCL API, the accuracy of the SYCL built-in functions is the same as the
+corresponding OpenCL functions.
+
+The accuracy of the OpenCL built-in functions is described in
+https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#relative-error-as-ulps
+and summarised below:
 
 function         |      float |     double
 -----------------|------------|------------
-acosf / acos     |         3  |         2*
-acoshf / acosh   |         2  |         2
-asinf / asin     |         4  |         1
-asinhf / asinh   |         2  |         2
-atan2f / atan2   |         3  |         2
-atanf / atan     |         1  |         2*
-atanhf / atanh   |         2  |         3
-cbrtf / cbrt     |         1  |         1
-cosf / cos       |         2  |         3*
-coshf / cosh     |         2  |         1
-erfcf / erfc     |         3  |         3
-erff / erf       |         1  |         1
-exp10f / exp10   |         1  |         1
-exp2f / exp2     |         1  |         1
-expf / exp       |         1  |         1
-expm1f / expm1   |         1  |         1
+acosf / acos     |         4  |         4
+acoshf / acosh   |         4  |         4
+asinf / asin     |         4  |         4
+asinhf / asinh   |         4  |         4
+atan2f / atan2   |         6  |         6
+atanf / atan     |         5  |         5*
+atanhf / atanh   |         5  |         5
+cbrtf / cbrt     |         2  |         2
+cosf / cos       |         4  |         4 
+coshf / cosh     |         4  |         4
+erfcf / erfc     |        16  |        16
+erff / erf       |        16  |        16
+exp10f / exp10   |         3  |         3
+exp2f / exp2     |         3  |         3
+expf / exp       |         3  |         3
+expm1f / expm1   |         3  |         3
 fabsf / fabs     |         0  |         0 
 fmaf / fma       |         0  |         0
+fmaxf / fmax     |         0  |         0
+fminf / fmin     |         0  |         0
 fmodf / fmod     |         0  |         0
-hypotf / hypot   |         1  |         2
-j0f / j0         |         3  |         4
-j1f / j1         |         3  |         4
-jnf / jn         |        80  |      2700
-lgammaf / lgamma |         3  |         4
-log10f / log10   |         2  |         1
-log1pf / log1p   |         1  |         1
-log2f / log2     |         1  |         1
-logf / log       |         1  |         1
+hypotf / hypot   |         4  |         4
+j0f / j0         |       n/a  |       n/a
+j1f / j1         |       n/a  |       n/a
+jnf / jn         |       n/a  |       n/a
+lgammaf / lgamma |       n/a  |       n/a
+log10f / log10   |         3  |         3
+log1pf / log1p   |         2  |         2
+log2f / log2     |         3  |         3
+logf / log       |         3  |         3
 pow10f / pow10   |       n/a  |       n/a
-powf / pow       |         2  |         1
-sincosf / sincos |         3  |         2
-sinf / sin       |         2  |         3*
-sinhf / sinh     |         2  |         2
+powf / pow       |        16  |        16
+sincosf / sincos |         4  |         4
+sinf / sin       |         4  |         4 
+sinhf / sinh     |         4  |         4
 sqrtf / sqrt     |         3† |         0†
-tanf / tan       |         4  |         2*
-tanhf / tanh     |         1  |         1
-tgammaf / tgamma |         3  |         9
-y0f / y0         |         4  |         6
-y1f / y1         |         5  |         4
-ynf / yn         |       145  |      2000
+tanf / tan       |         5  |         5
+tanhf / tanh     |         5  |         5
+tgammaf / tgamma |        16  |        16
+y0f / y0         |       n/a  |       n/a
+y1f / y1         |       n/a  |       n/a
+ynf / yn         |       n/a  |       n/a
 
-  - † according to the OpenCL standard; may be affected by the `-ffast-math` compiler option.
-  - * 1 ULP according to the documentation
+  - † may be affected by the `-ffast-math` compiler option.
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -187,8 +187,8 @@ ifneq ($(ONEAPI_BASE),)
 
   # Enable double precision floating point emulation for Intel GPUs
   # See https://github.com/intel/compute-runtime/blob/master/opencl/doc/FAQ.md#feature-double-precision-emulation-fp64
-  export IGC_EnableDPEmulation := 1
-  export OverrideDefaultFP64Settings := 1
+  #export IGC_EnableDPEmulation := 1
+  #export OverrideDefaultFP64Settings := 1
 endif
 
 # xtd

--- a/test/abs/abs_t.sycl.cc
+++ b/test/abs/abs_t.sycl.cc
@@ -37,30 +37,26 @@ TEST_CASE("xtd::abs", "[abs][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::abs(float)") {
-              test<float, float, xtd::abs, mpfr::fabs>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::abs(float)") {
+            test<float, float, xtd::abs, mpfr::fabs>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::abs(double)") {
-              test<double, double, xtd::abs, mpfr::fabs>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::abs(double)") {
+            test<double, double, xtd::abs, mpfr::fabs>(queue, values, ulps_double);
+          }
 
-            SECTION("int xtd::abs(int)") {
-              test_i<int, xtd::abs, std::abs>(queue, values);
-            }
+          SECTION("int xtd::abs(int)") {
+            test_i<int, xtd::abs, std::abs>(queue, values);
+          }
 
-            SECTION("long long xtd::abs(long long)") {
-              test_i<long long, xtd::abs, std::abs>(queue, values);
-            }
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("long long xtd::abs(long long)") {
+            test_i<long long, xtd::abs, std::abs>(queue, values);
           }
         }
       }

--- a/test/acos/acos_t.sycl.cc
+++ b/test/acos/acos_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 3;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 4;
 
 TEST_CASE("xtd::acos", "[acos][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/acos/acos_t.sycl.cc
+++ b/test/acos/acos_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::acos", "[acos][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::acos(float)") {
-              test<float, float, xtd::acos, mpfr::acos>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::acos(float)") {
+            test<float, float, xtd::acos, mpfr::acos>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::acos(double)") {
-              test<double, double, xtd::acos, mpfr::acos>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::acos(double)") {
+            test<double, double, xtd::acos, mpfr::acos>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::acos(int)") {
-              test<double, int, xtd::acos, mpfr::acos>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::acos(int)") {
+            test<double, int, xtd::acos, mpfr::acos>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::acosf(float)") {
-              test_f<float, float, xtd::acosf, mpfr::acos>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::acosf(float)") {
+            test_f<float, float, xtd::acosf, mpfr::acos>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::acosf(double)") {
-              test_f<float, double, xtd::acosf, mpfr::acos>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::acosf(double)") {
+            test_f<float, double, xtd::acosf, mpfr::acos>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::acosf(int)") {
-              test_f<float, int, xtd::acosf, mpfr::acos>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::acosf(int)") {
+            test_f<float, int, xtd::acosf, mpfr::acos>(queue, values, ulps_float);
           }
         }
       }

--- a/test/acosh/acosh_t.sycl.cc
+++ b/test/acosh/acosh_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::acosh", "[acosh][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::acosh(float)") {
-              test<float, float, xtd::acosh, mpfr::acosh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::acosh(float)") {
+            test<float, float, xtd::acosh, mpfr::acosh>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::acosh(double)") {
-              test<double, double, xtd::acosh, mpfr::acosh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::acosh(double)") {
+            test<double, double, xtd::acosh, mpfr::acosh>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::acosh(int)") {
-              test<double, int, xtd::acosh, mpfr::acosh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::acosh(int)") {
+            test<double, int, xtd::acosh, mpfr::acosh>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::acoshf(float)") {
-              test_f<float, float, xtd::acoshf, mpfr::acosh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::acoshf(float)") {
+            test_f<float, float, xtd::acoshf, mpfr::acosh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::acoshf(double)") {
-              test_f<float, double, xtd::acoshf, mpfr::acosh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::acoshf(double)") {
+            test_f<float, double, xtd::acoshf, mpfr::acosh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::acoshf(int)") {
-              test_f<float, int, xtd::acoshf, mpfr::acosh>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::acoshf(int)") {
+            test_f<float, int, xtd::acoshf, mpfr::acosh>(queue, values, ulps_float);
           }
         }
       }

--- a/test/acosh/acosh_t.sycl.cc
+++ b/test/acosh/acosh_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 4;
 
 TEST_CASE("xtd::acosh", "[acosh][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/asin/asin_t.sycl.cc
+++ b/test/asin/asin_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::asin", "[asin][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::asin(float)") {
-              test<float, float, xtd::asin, mpfr::asin>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::asin(float)") {
+            test<float, float, xtd::asin, mpfr::asin>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::asin(double)") {
-              test<double, double, xtd::asin, mpfr::asin>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::asin(double)") {
+            test<double, double, xtd::asin, mpfr::asin>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::asin(int)") {
-              test<double, int, xtd::asin, mpfr::asin>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::asin(int)") {
+            test<double, int, xtd::asin, mpfr::asin>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::asinf(float)") {
-              test_f<float, float, xtd::asinf, mpfr::asin>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::asinf(float)") {
+            test_f<float, float, xtd::asinf, mpfr::asin>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::asinf(double)") {
-              test_f<float, double, xtd::asinf, mpfr::asin>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::asinf(double)") {
+            test_f<float, double, xtd::asinf, mpfr::asin>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::asinf(int)") {
-              test_f<float, int, xtd::asinf, mpfr::asin>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::asinf(int)") {
+            test_f<float, int, xtd::asinf, mpfr::asin>(queue, values, ulps_float);
           }
         }
       }

--- a/test/asin/asin_t.sycl.cc
+++ b/test/asin/asin_t.sycl.cc
@@ -28,7 +28,7 @@
 #include "common/math_inputs.h"
 
 constexpr int ulps_float = 4;
-constexpr int ulps_double = 1;
+constexpr int ulps_double = 4;
 
 TEST_CASE("xtd::asin", "[asin][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/asinh/asinh_t.sycl.cc
+++ b/test/asinh/asinh_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::asinh", "[asinh][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::asinh(float)") {
-              test<float, float, xtd::asinh, mpfr::asinh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::asinh(float)") {
+            test<float, float, xtd::asinh, mpfr::asinh>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::asinh(double)") {
-              test<double, double, xtd::asinh, mpfr::asinh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::asinh(double)") {
+            test<double, double, xtd::asinh, mpfr::asinh>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::asinh(int)") {
-              test<double, int, xtd::asinh, mpfr::asinh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::asinh(int)") {
+            test<double, int, xtd::asinh, mpfr::asinh>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::asinhf(float)") {
-              test_f<float, float, xtd::asinhf, mpfr::asinh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::asinhf(float)") {
+            test_f<float, float, xtd::asinhf, mpfr::asinh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::asinhf(double)") {
-              test_f<float, double, xtd::asinhf, mpfr::asinh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::asinhf(double)") {
+            test_f<float, double, xtd::asinhf, mpfr::asinh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::asinhf(int)") {
-              test_f<float, int, xtd::asinhf, mpfr::asinh>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::asinhf(int)") {
+            test_f<float, int, xtd::asinhf, mpfr::asinh>(queue, values, ulps_float);
           }
         }
       }

--- a/test/asinh/asinh_t.sycl.cc
+++ b/test/asinh/asinh_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 4;
 
 TEST_CASE("xtd::asinh", "[asinh][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/atan/atan_t.sycl.cc
+++ b/test/atan/atan_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::atan", "[atan][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::atan(float)") {
-              test<float, float, xtd::atan, mpfr::atan>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atan(float)") {
+            test<float, float, xtd::atan, mpfr::atan>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::atan(double)") {
-              test<double, double, xtd::atan, mpfr::atan>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::atan(double)") {
+            test<double, double, xtd::atan, mpfr::atan>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::atan(int)") {
-              test<double, int, xtd::atan, mpfr::atan>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::atan(int)") {
+            test<double, int, xtd::atan, mpfr::atan>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::atanf(float)") {
-              test_f<float, float, xtd::atanf, mpfr::atan>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atanf(float)") {
+            test_f<float, float, xtd::atanf, mpfr::atan>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::atanf(double)") {
-              test_f<float, double, xtd::atanf, mpfr::atan>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atanf(double)") {
+            test_f<float, double, xtd::atanf, mpfr::atan>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::atanf(int)") {
-              test_f<float, int, xtd::atanf, mpfr::atan>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::atanf(int)") {
+            test_f<float, int, xtd::atanf, mpfr::atan>(queue, values, ulps_float);
           }
         }
       }

--- a/test/atan/atan_t.sycl.cc
+++ b/test/atan/atan_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 5;
+constexpr int ulps_double = 5;
 
 TEST_CASE("xtd::atan", "[atan][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/atan2/atan2_t.sycl.cc
+++ b/test/atan2/atan2_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test2.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 3;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 6;
+constexpr int ulps_double = 6;
 
 constexpr auto ref_atan2 = [](mpfr_double y, mpfr_double x) { return mpfr::atan2(y, x); };
 constexpr auto ref_atan2f = [](mpfr_single y, mpfr_single x) { return mpfr::atan2(y, x); };

--- a/test/atan2/atan2_t.sycl.cc
+++ b/test/atan2/atan2_t.sycl.cc
@@ -40,39 +40,34 @@ TEST_CASE("xtd::atan2", "[atan2][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::atan2(float, float)") {
-              test_2<float, float, xtd::atan2, ref_atan2>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atan2(float, float)") {
+            test_2<float, float, xtd::atan2, ref_atan2>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::atan2(double, double)") {
-              test_2<double, double, xtd::atan2, ref_atan2>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::atan2(double, double)") {
+            test_2<double, double, xtd::atan2, ref_atan2>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::atan2(int, int)") {
-              test_2<double, int, xtd::atan2, ref_atan2>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::atan2(int, int)") {
+            test_2<double, int, xtd::atan2, ref_atan2>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::atan2f(float, float)") {
-              test_2f<float, float, xtd::atan2f, ref_atan2f>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atan2f(float, float)") {
+            test_2f<float, float, xtd::atan2f, ref_atan2f>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::atan2f(double, double)") {
-              test_2f<float, double, xtd::atan2f, ref_atan2f>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atan2f(double, double)") {
+            test_2f<float, double, xtd::atan2f, ref_atan2f>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::atan2f(int, int)") {
-              test_2f<float, int, xtd::atan2f, ref_atan2f>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::atan2f(int, int)") {
+            test_2f<float, int, xtd::atan2f, ref_atan2f>(queue, values, ulps_float);
           }
         }
       }

--- a/test/atanh/atanh_t.sycl.cc
+++ b/test/atanh/atanh_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::atanh", "[atanh][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::atanh(float)") {
-              test<float, float, xtd::atanh, mpfr::atanh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atanh(float)") {
+            test<float, float, xtd::atanh, mpfr::atanh>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::atanh(double)") {
-              test<double, double, xtd::atanh, mpfr::atanh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::atanh(double)") {
+            test<double, double, xtd::atanh, mpfr::atanh>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::atanh(int)") {
-              test<double, int, xtd::atanh, mpfr::atanh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::atanh(int)") {
+            test<double, int, xtd::atanh, mpfr::atanh>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::atanhf(float)") {
-              test_f<float, float, xtd::atanhf, mpfr::atanh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atanhf(float)") {
+            test_f<float, float, xtd::atanhf, mpfr::atanh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::atanhf(double)") {
-              test_f<float, double, xtd::atanhf, mpfr::atanh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::atanhf(double)") {
+            test_f<float, double, xtd::atanhf, mpfr::atanh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::atanhf(int)") {
-              test_f<float, int, xtd::atanhf, mpfr::atanh>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::atanhf(int)") {
+            test_f<float, int, xtd::atanhf, mpfr::atanh>(queue, values, ulps_float);
           }
         }
       }

--- a/test/atanh/atanh_t.sycl.cc
+++ b/test/atanh/atanh_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 3;
+constexpr int ulps_float = 5;
+constexpr int ulps_double = 5;
 
 TEST_CASE("xtd::atanh", "[atanh][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/cbrt/cbrt_t.sycl.cc
+++ b/test/cbrt/cbrt_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::cbrt", "[cbrt][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::cbrt(float)") {
-              test<float, float, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::cbrt(float)") {
+            test<float, float, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::cbrt(double)") {
-              test<double, double, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::cbrt(double)") {
+            test<double, double, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::cbrt(int)") {
-              test<double, int, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::cbrt(int)") {
+            test<double, int, xtd::cbrt, mpfr::cbrt>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::cbrtf(float)") {
-              test_f<float, float, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::cbrtf(float)") {
+            test_f<float, float, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::cbrtf(double)") {
-              test_f<float, double, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::cbrtf(double)") {
+            test_f<float, double, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::cbrtf(int)") {
-              test_f<float, int, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::cbrtf(int)") {
+            test_f<float, int, xtd::cbrtf, mpfr::cbrt>(queue, values, ulps_float);
           }
         }
       }

--- a/test/cbrt/cbrt_t.sycl.cc
+++ b/test/cbrt/cbrt_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 2;
 
 TEST_CASE("xtd::cbrt", "[cbrt][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/ceil/ceil_t.sycl.cc
+++ b/test/ceil/ceil_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::ceil", "[ceil][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::ceil(float)") {
-              test<float, float, xtd::ceil, mpfr::ceil>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::ceil(float)") {
+            test<float, float, xtd::ceil, mpfr::ceil>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::ceil(double)") {
-              test<double, double, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::ceil(double)") {
+            test<double, double, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::ceil(int)") {
-              test<double, int, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::ceil(int)") {
+            test<double, int, xtd::ceil, mpfr::ceil>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::ceilf(float)") {
-              test_f<float, float, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::ceilf(float)") {
+            test_f<float, float, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::ceilf(double)") {
-              test_f<float, double, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::ceilf(double)") {
+            test_f<float, double, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::ceilf(int)") {
-              test_f<float, int, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::ceilf(int)") {
+            test_f<float, int, xtd::ceilf, mpfr::ceil>(queue, values, ulps_float);
           }
         }
       }

--- a/test/cos/cos_t.sycl.cc
+++ b/test/cos/cos_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 3;
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 4;
 
 TEST_CASE("xtd::cos", "[cos][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/cos/cos_t.sycl.cc
+++ b/test/cos/cos_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::cos", "[cos][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::cos(float)") {
-              test<float, float, xtd::cos, mpfr::cos>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::cos(float)") {
+            test<float, float, xtd::cos, mpfr::cos>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::cos(double)") {
-              test<double, double, xtd::cos, mpfr::cos>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::cos(double)") {
+            test<double, double, xtd::cos, mpfr::cos>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::cos(int)") {
-              test<double, int, xtd::cos, mpfr::cos>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::cos(int)") {
+            test<double, int, xtd::cos, mpfr::cos>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::cosf(float)") {
-              test_f<float, float, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::cosf(float)") {
+            test_f<float, float, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::cosf(double)") {
-              test_f<float, double, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::cosf(double)") {
+            test_f<float, double, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::cosf(int)") {
-              test_f<float, int, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::cosf(int)") {
+            test_f<float, int, xtd::cosf, mpfr::cos>(queue, values, ulps_float);
           }
         }
       }

--- a/test/cosh/cosh_t.sycl.cc
+++ b/test/cosh/cosh_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 4;
 
 TEST_CASE("xtd::cosh", "[cosh][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/cosh/cosh_t.sycl.cc
+++ b/test/cosh/cosh_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::cosh", "[cosh][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::cosh(float)") {
-              test<float, float, xtd::cosh, mpfr::cosh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::cosh(float)") {
+            test<float, float, xtd::cosh, mpfr::cosh>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::cosh(double)") {
-              test<double, double, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::cosh(double)") {
+            test<double, double, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::cosh(int)") {
-              test<double, int, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::cosh(int)") {
+            test<double, int, xtd::cosh, mpfr::cosh>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::coshf(float)") {
-              test_f<float, float, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::coshf(float)") {
+            test_f<float, float, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::coshf(double)") {
-              test_f<float, double, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::coshf(double)") {
+            test_f<float, double, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::coshf(int)") {
-              test_f<float, int, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::coshf(int)") {
+            test_f<float, int, xtd::coshf, mpfr::cosh>(queue, values, ulps_float);
           }
         }
       }

--- a/test/exp/exp_t.sycl.cc
+++ b/test/exp/exp_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::exp", "[exp][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::exp(float)") {
-              test<float, float, xtd::exp, mpfr::exp>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::exp(float)") {
+            test<float, float, xtd::exp, mpfr::exp>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::exp(double)") {
-              test<double, double, xtd::exp, mpfr::exp>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::exp(double)") {
+            test<double, double, xtd::exp, mpfr::exp>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::exp(int)") {
-              test<double, int, xtd::exp, mpfr::exp>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::exp(int)") {
+            test<double, int, xtd::exp, mpfr::exp>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::expf(float)") {
-              test_f<float, float, xtd::expf, mpfr::exp>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::expf(float)") {
+            test_f<float, float, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::expf(double)") {
-              test_f<float, double, xtd::expf, mpfr::exp>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::expf(double)") {
+            test_f<float, double, xtd::expf, mpfr::exp>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::expf(int)") {
-              test_f<float, int, xtd::expf, mpfr::exp>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::expf(int)") {
+            test_f<float, int, xtd::expf, mpfr::exp>(queue, values, ulps_float);
           }
         }
       }

--- a/test/exp/exp_t.sycl.cc
+++ b/test/exp/exp_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 3;
+constexpr int ulps_double = 3;
 
 TEST_CASE("xtd::exp", "[exp][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/exp2/exp2_t.sycl.cc
+++ b/test/exp2/exp2_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 3;
+constexpr int ulps_double = 3;
 
 TEST_CASE("xtd::exp2", "[exp2][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/exp2/exp2_t.sycl.cc
+++ b/test/exp2/exp2_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::exp2", "[exp2][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::exp2(float)") {
-              test<float, float, xtd::exp2, mpfr::exp2>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::exp2(float)") {
+            test<float, float, xtd::exp2, mpfr::exp2>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::exp2(double)") {
-              test<double, double, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::exp2(double)") {
+            test<double, double, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::exp2(int)") {
-              test<double, int, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::exp2(int)") {
+            test<double, int, xtd::exp2, mpfr::exp2>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::exp2f(float)") {
-              test_f<float, float, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::exp2f(float)") {
+            test_f<float, float, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::exp2f(double)") {
-              test_f<float, double, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::exp2f(double)") {
+            test_f<float, double, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::exp2f(int)") {
-              test_f<float, int, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::exp2f(int)") {
+            test_f<float, int, xtd::exp2f, mpfr::exp2>(queue, values, ulps_float);
           }
         }
       }

--- a/test/expm1/expm1_t.sycl.cc
+++ b/test/expm1/expm1_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::expm1", "[expm1][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::expm1(float)") {
-              test<float, float, xtd::expm1, mpfr::expm1>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::expm1(float)") {
+            test<float, float, xtd::expm1, mpfr::expm1>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::expm1(double)") {
-              test<double, double, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::expm1(double)") {
+            test<double, double, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::expm1(int)") {
-              test<double, int, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::expm1(int)") {
+            test<double, int, xtd::expm1, mpfr::expm1>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::expm1f(float)") {
-              test_f<float, float, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::expm1f(float)") {
+            test_f<float, float, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::expm1f(double)") {
-              test_f<float, double, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::expm1f(double)") {
+            test_f<float, double, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::expm1f(int)") {
-              test_f<float, int, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::expm1f(int)") {
+            test_f<float, int, xtd::expm1f, mpfr::expm1>(queue, values, ulps_float);
           }
         }
       }

--- a/test/expm1/expm1_t.sycl.cc
+++ b/test/expm1/expm1_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 3;
+constexpr int ulps_double = 3;
 
 TEST_CASE("xtd::expm1", "[expm1][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/fabs/fabs_t.sycl.cc
+++ b/test/fabs/fabs_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::fabs", "[fabs][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::fabs(float)") {
-              test<float, float, xtd::fabs, mpfr::fabs>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fabs(float)") {
+            test<float, float, xtd::fabs, mpfr::fabs>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::fabs(double)") {
-              test<double, double, xtd::fabs, mpfr::fabs>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fabs(double)") {
+            test<double, double, xtd::fabs, mpfr::fabs>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::fabs(int)") {
-              test<double, int, xtd::fabs, mpfr::fabs>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fabs(int)") {
+            test<double, int, xtd::fabs, mpfr::fabs>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::fabsf(float)") {
-              test_f<float, float, xtd::fabsf, mpfr::fabs>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fabsf(float)") {
+            test_f<float, float, xtd::fabsf, mpfr::fabs>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fabsf(double)") {
-              test_f<float, double, xtd::fabsf, mpfr::fabs>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fabsf(double)") {
+            test_f<float, double, xtd::fabsf, mpfr::fabs>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fabsf(int)") {
-              test_f<float, int, xtd::fabsf, mpfr::fabs>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::fabsf(int)") {
+            test_f<float, int, xtd::fabsf, mpfr::fabs>(queue, values, ulps_float);
           }
         }
       }

--- a/test/fdim/fdim_t.sycl.cc
+++ b/test/fdim/fdim_t.sycl.cc
@@ -40,39 +40,34 @@ TEST_CASE("xtd::fdim", "[fdim][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::fdim(float, float)") {
-              test_2<float, float, xtd::fdim, ref_fdim>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fdim(float, float)") {
+            test_2<float, float, xtd::fdim, ref_fdim>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::fdim(double, double)") {
-              test_2<double, double, xtd::fdim, ref_fdim>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fdim(double, double)") {
+            test_2<double, double, xtd::fdim, ref_fdim>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::fdim(int, int)") {
-              test_2<double, int, xtd::fdim, ref_fdim>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fdim(int, int)") {
+            test_2<double, int, xtd::fdim, ref_fdim>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::fdimf(float, float)") {
-              test_2f<float, float, xtd::fdimf, ref_fdimf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fdimf(float, float)") {
+            test_2f<float, float, xtd::fdimf, ref_fdimf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fdimf(double, double)") {
-              test_2f<float, double, xtd::fdimf, ref_fdimf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fdimf(double, double)") {
+            test_2f<float, double, xtd::fdimf, ref_fdimf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fdimf(int, int)") {
-              test_2f<float, int, xtd::fdimf, ref_fdimf>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::fdimf(int, int)") {
+            test_2f<float, int, xtd::fdimf, ref_fdimf>(queue, values, ulps_float);
           }
         }
       }

--- a/test/fdim/fdim_t.sycl.cc
+++ b/test/fdim/fdim_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test2.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 3;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 0;
+constexpr int ulps_double = 0;
 
 constexpr auto ref_fdim = [](mpfr_double y, mpfr_double x) { return mpfr::fdim(y, x); };
 constexpr auto ref_fdimf = [](mpfr_single y, mpfr_single x) { return mpfr::fdim(y, x); };

--- a/test/floor/floor_t.sycl.cc
+++ b/test/floor/floor_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::floor", "[floor][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::floor(float)") {
-              test<float, float, xtd::floor, mpfr::floor>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::floor(float)") {
+            test<float, float, xtd::floor, mpfr::floor>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::floor(double)") {
-              test<double, double, xtd::floor, mpfr::floor>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::floor(double)") {
+            test<double, double, xtd::floor, mpfr::floor>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::floor(int)") {
-              test<double, int, xtd::floor, mpfr::floor>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::floor(int)") {
+            test<double, int, xtd::floor, mpfr::floor>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::floorf(float)") {
-              test_f<float, float, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::floorf(float)") {
+            test_f<float, float, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::floorf(double)") {
-              test_f<float, double, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::floorf(double)") {
+            test_f<float, double, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::floorf(int)") {
-              test_f<float, int, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::floorf(int)") {
+            test_f<float, int, xtd::floorf, mpfr::floor>(queue, values, ulps_float);
           }
         }
       }

--- a/test/fmax/fmax_t.sycl.cc
+++ b/test/fmax/fmax_t.sycl.cc
@@ -40,39 +40,34 @@ TEST_CASE("xtd::fmax", "[fmax][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::fmax(float, float)") {
-              test_2<float, float, xtd::fmax, ref_fmax>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fmax(float, float)") {
+            test_2<float, float, xtd::fmax, ref_fmax>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::fmax(double, double)") {
-              test_2<double, double, xtd::fmax, ref_fmax>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fmax(double, double)") {
+            test_2<double, double, xtd::fmax, ref_fmax>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::fmax(int, int)") {
-              test_2<double, int, xtd::fmax, ref_fmax>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fmax(int, int)") {
+            test_2<double, int, xtd::fmax, ref_fmax>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::fmaxf(float, float)") {
-              test_2f<float, float, xtd::fmaxf, ref_fmaxf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fmaxf(float, float)") {
+            test_2f<float, float, xtd::fmaxf, ref_fmaxf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fmaxf(double, double)") {
-              test_2f<float, double, xtd::fmaxf, ref_fmaxf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fmaxf(double, double)") {
+            test_2f<float, double, xtd::fmaxf, ref_fmaxf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fmaxf(int, int)") {
-              test_2f<float, int, xtd::fmaxf, ref_fmaxf>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::fmaxf(int, int)") {
+            test_2f<float, int, xtd::fmaxf, ref_fmaxf>(queue, values, ulps_float);
           }
         }
       }

--- a/test/fmin/fmin_t.sycl.cc
+++ b/test/fmin/fmin_t.sycl.cc
@@ -40,39 +40,34 @@ TEST_CASE("xtd::fmin", "[fmin][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::fmin(float, float)") {
-              test_2<float, float, xtd::fmin, ref_fmin>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fmin(float, float)") {
+            test_2<float, float, xtd::fmin, ref_fmin>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::fmin(double, double)") {
-              test_2<double, double, xtd::fmin, ref_fmin>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fmin(double, double)") {
+            test_2<double, double, xtd::fmin, ref_fmin>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::fmin(int, int)") {
-              test_2<double, int, xtd::fmin, ref_fmin>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fmin(int, int)") {
+            test_2<double, int, xtd::fmin, ref_fmin>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::fminf(float, float)") {
-              test_2f<float, float, xtd::fminf, ref_fminf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fminf(float, float)") {
+            test_2f<float, float, xtd::fminf, ref_fminf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fminf(double, double)") {
-              test_2f<float, double, xtd::fminf, ref_fminf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fminf(double, double)") {
+            test_2f<float, double, xtd::fminf, ref_fminf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fminf(int, int)") {
-              test_2f<float, int, xtd::fminf, ref_fminf>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::fminf(int, int)") {
+            test_2f<float, int, xtd::fminf, ref_fminf>(queue, values, ulps_float);
           }
         }
       }

--- a/test/fmod/fmod_t.sycl.cc
+++ b/test/fmod/fmod_t.sycl.cc
@@ -40,39 +40,34 @@ TEST_CASE("xtd::fmod", "[fmod][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::fmod(float, float)") {
-              test_2<float, float, xtd::fmod, ref_fmod>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fmod(float, float)") {
+            test_2<float, float, xtd::fmod, ref_fmod>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::fmod(double, double)") {
-              test_2<double, double, xtd::fmod, ref_fmod>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fmod(double, double)") {
+            test_2<double, double, xtd::fmod, ref_fmod>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::fmod(int, int)") {
-              test_2<double, int, xtd::fmod, ref_fmod>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::fmod(int, int)") {
+            test_2<double, int, xtd::fmod, ref_fmod>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::fmodf(float, float)") {
-              test_2f<float, float, xtd::fmodf, ref_fmodf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fmodf(float, float)") {
+            test_2f<float, float, xtd::fmodf, ref_fmodf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fmodf(double, double)") {
-              test_2f<float, double, xtd::fmodf, ref_fmodf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::fmodf(double, double)") {
+            test_2f<float, double, xtd::fmodf, ref_fmodf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::fmodf(int, int)") {
-              test_2f<float, int, xtd::fmodf, ref_fmodf>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::fmodf(int, int)") {
+            test_2f<float, int, xtd::fmodf, ref_fmodf>(queue, values, ulps_float);
           }
         }
       }

--- a/test/hypot/hypot_t.sycl.cc
+++ b/test/hypot/hypot_t.sycl.cc
@@ -40,39 +40,34 @@ TEST_CASE("xtd::hypot", "[hypot][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::hypot(float, float)") {
-              test_2<float, float, xtd::hypot, ref_hypot>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::hypot(float, float)") {
+            test_2<float, float, xtd::hypot, ref_hypot>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::hypot(double, double)") {
-              test_2<double, double, xtd::hypot, ref_hypot>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::hypot(double, double)") {
+            test_2<double, double, xtd::hypot, ref_hypot>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::hypot(int, int)") {
-              test_2<double, int, xtd::hypot, ref_hypot>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::hypot(int, int)") {
+            test_2<double, int, xtd::hypot, ref_hypot>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::hypotf(float, float)") {
-              test_2f<float, float, xtd::hypotf, ref_hypotf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::hypotf(float, float)") {
+            test_2f<float, float, xtd::hypotf, ref_hypotf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::hypotf(double, double)") {
-              test_2f<float, double, xtd::hypotf, ref_hypotf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::hypotf(double, double)") {
+            test_2f<float, double, xtd::hypotf, ref_hypotf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::hypotf(int, int)") {
-              test_2f<float, int, xtd::hypotf, ref_hypotf>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::hypotf(int, int)") {
+            test_2f<float, int, xtd::hypotf, ref_hypotf>(queue, values, ulps_float);
           }
         }
       }

--- a/test/hypot/hypot_t.sycl.cc
+++ b/test/hypot/hypot_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test2.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 3;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 4;
 
 constexpr auto ref_hypot = [](mpfr_double y, mpfr_double x) { return mpfr::hypot(y, x); };
 constexpr auto ref_hypotf = [](mpfr_single y, mpfr_single x) { return mpfr::hypot(y, x); };

--- a/test/log/log_t.sycl.cc
+++ b/test/log/log_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::log", "[log][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::log(float)") {
-              test<float, float, xtd::log, mpfr::log>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log(float)") {
+            test<float, float, xtd::log, mpfr::log>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::log(double)") {
-              test<double, double, xtd::log, mpfr::log>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::log(double)") {
+            test<double, double, xtd::log, mpfr::log>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::log(int)") {
-              test<double, int, xtd::log, mpfr::log>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::log(int)") {
+            test<double, int, xtd::log, mpfr::log>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::logf(float)") {
-              test_f<float, float, xtd::logf, mpfr::log>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::logf(float)") {
+            test_f<float, float, xtd::logf, mpfr::log>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::logf(double)") {
-              test_f<float, double, xtd::logf, mpfr::log>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::logf(double)") {
+            test_f<float, double, xtd::logf, mpfr::log>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::logf(int)") {
-              test_f<float, int, xtd::logf, mpfr::log>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::logf(int)") {
+            test_f<float, int, xtd::logf, mpfr::log>(queue, values, ulps_float);
           }
         }
       }

--- a/test/log/log_t.sycl.cc
+++ b/test/log/log_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 3;
+constexpr int ulps_double = 3;
 
 TEST_CASE("xtd::log", "[log][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/log10/log10_t.sycl.cc
+++ b/test/log10/log10_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 3;
+constexpr int ulps_double = 3;
 
 TEST_CASE("xtd::log10", "[log10][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/log10/log10_t.sycl.cc
+++ b/test/log10/log10_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::log10", "[log10][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::log10(float)") {
-              test<float, float, xtd::log10, mpfr::log10>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log10(float)") {
+            test<float, float, xtd::log10, mpfr::log10>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::log10(double)") {
-              test<double, double, xtd::log10, mpfr::log10>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::log10(double)") {
+            test<double, double, xtd::log10, mpfr::log10>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::log10(int)") {
-              test<double, int, xtd::log10, mpfr::log10>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::log10(int)") {
+            test<double, int, xtd::log10, mpfr::log10>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::log10f(float)") {
-              test_f<float, float, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log10f(float)") {
+            test_f<float, float, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::log10f(double)") {
-              test_f<float, double, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log10f(double)") {
+            test_f<float, double, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::log10f(int)") {
-              test_f<float, int, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::log10f(int)") {
+            test_f<float, int, xtd::log10f, mpfr::log10>(queue, values, ulps_float);
           }
         }
       }

--- a/test/log1p/log1p_t.sycl.cc
+++ b/test/log1p/log1p_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::log1p", "[log1p][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::log1p(float)") {
-              test<float, float, xtd::log1p, mpfr::log1p>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log1p(float)") {
+            test<float, float, xtd::log1p, mpfr::log1p>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::log1p(double)") {
-              test<double, double, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::log1p(double)") {
+            test<double, double, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::log1p(int)") {
-              test<double, int, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::log1p(int)") {
+            test<double, int, xtd::log1p, mpfr::log1p>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::log1pf(float)") {
-              test_f<float, float, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log1pf(float)") {
+            test_f<float, float, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::log1pf(double)") {
-              test_f<float, double, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log1pf(double)") {
+            test_f<float, double, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::log1pf(int)") {
-              test_f<float, int, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::log1pf(int)") {
+            test_f<float, int, xtd::log1pf, mpfr::log1p>(queue, values, ulps_float);
           }
         }
       }

--- a/test/log1p/log1p_t.sycl.cc
+++ b/test/log1p/log1p_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 2;
+constexpr int ulps_double = 2;
 
 TEST_CASE("xtd::log1p", "[log1p][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/log2/log2_t.sycl.cc
+++ b/test/log2/log2_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::log2", "[log2][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::log2(float)") {
-              test<float, float, xtd::log2, mpfr::log2>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log2(float)") {
+            test<float, float, xtd::log2, mpfr::log2>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::log2(double)") {
-              test<double, double, xtd::log2, mpfr::log2>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::log2(double)") {
+            test<double, double, xtd::log2, mpfr::log2>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::log2(int)") {
-              test<double, int, xtd::log2, mpfr::log2>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::log2(int)") {
+            test<double, int, xtd::log2, mpfr::log2>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::log2f(float)") {
-              test_f<float, float, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log2f(float)") {
+            test_f<float, float, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::log2f(double)") {
-              test_f<float, double, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::log2f(double)") {
+            test_f<float, double, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::log2f(int)") {
-              test_f<float, int, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::log2f(int)") {
+            test_f<float, int, xtd::log2f, mpfr::log2>(queue, values, ulps_float);
           }
         }
       }

--- a/test/log2/log2_t.sycl.cc
+++ b/test/log2/log2_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 3;
+constexpr int ulps_double = 3;
 
 TEST_CASE("xtd::log2", "[log2][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/pow/pow_t.sycl.cc
+++ b/test/pow/pow_t.sycl.cc
@@ -40,39 +40,34 @@ TEST_CASE("xtd::pow", "[pow][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::pow(float, float)") {
-              test_2<float, float, xtd::pow, ref_pow>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::pow(float, float)") {
+            test_2<float, float, xtd::pow, ref_pow>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::pow(double, double)") {
-              test_2<double, double, xtd::pow, ref_pow>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::pow(double, double)") {
+            test_2<double, double, xtd::pow, ref_pow>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::pow(int, int)") {
-              test_2<double, int, xtd::pow, ref_pow>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::pow(int, int)") {
+            test_2<double, int, xtd::pow, ref_pow>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::powf(float, float)") {
-              test_2f<float, float, xtd::powf, ref_powf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::powf(float, float)") {
+            test_2f<float, float, xtd::powf, ref_powf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::powf(double, double)") {
-              test_2f<float, double, xtd::powf, ref_powf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::powf(double, double)") {
+            test_2f<float, double, xtd::powf, ref_powf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::powf(int, int)") {
-              test_2f<float, int, xtd::powf, ref_powf>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::powf(int, int)") {
+            test_2f<float, int, xtd::powf, ref_powf>(queue, values, ulps_float);
           }
         }
       }

--- a/test/pow/pow_t.sycl.cc
+++ b/test/pow/pow_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test2.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 16;
+constexpr int ulps_double = 16;
 
 constexpr auto ref_pow = [](mpfr_double y, mpfr_double x) { return mpfr::pow(y, x); };
 constexpr auto ref_powf = [](mpfr_single y, mpfr_single x) { return mpfr::pow(y, x); };

--- a/test/remainder/remainder_t.sycl.cc
+++ b/test/remainder/remainder_t.sycl.cc
@@ -40,39 +40,34 @@ TEST_CASE("xtd::remainder", "[remainder][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::remainder(float, float)") {
-              test_2<float, float, xtd::remainder, ref_remainder>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::remainder(float, float)") {
+            test_2<float, float, xtd::remainder, ref_remainder>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::remainder(double, double)") {
-              test_2<double, double, xtd::remainder, ref_remainder>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::remainder(double, double)") {
+            test_2<double, double, xtd::remainder, ref_remainder>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::remainder(int, int)") {
-              test_2<double, int, xtd::remainder, ref_remainder>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::remainder(int, int)") {
+            test_2<double, int, xtd::remainder, ref_remainder>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::remainderf(float, float)") {
-              test_2f<float, float, xtd::remainderf, ref_remainderf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::remainderf(float, float)") {
+            test_2f<float, float, xtd::remainderf, ref_remainderf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::remainderf(double, double)") {
-              test_2f<float, double, xtd::remainderf, ref_remainderf>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::remainderf(double, double)") {
+            test_2f<float, double, xtd::remainderf, ref_remainderf>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::remainderf(int, int)") {
-              test_2f<float, int, xtd::remainderf, ref_remainderf>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::remainderf(int, int)") {
+            test_2f<float, int, xtd::remainderf, ref_remainderf>(queue, values, ulps_float);
           }
         }
       }

--- a/test/sin/sin_t.sycl.cc
+++ b/test/sin/sin_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 3;
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 4;
 
 TEST_CASE("xtd::sin", "[sin][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/sin/sin_t.sycl.cc
+++ b/test/sin/sin_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::sin", "[sin][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::sin(float)") {
-              test<float, float, xtd::sin, mpfr::sin>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sin(float)") {
+            test<float, float, xtd::sin, mpfr::sin>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::sin(double)") {
-              test<double, double, xtd::sin, mpfr::sin>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::sin(double)") {
+            test<double, double, xtd::sin, mpfr::sin>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::sin(int)") {
-              test<double, int, xtd::sin, mpfr::sin>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::sin(int)") {
+            test<double, int, xtd::sin, mpfr::sin>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::sinf(float)") {
-              test_f<float, float, xtd::sinf, mpfr::sin>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sinf(float)") {
+            test_f<float, float, xtd::sinf, mpfr::sin>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::sinf(double)") {
-              test_f<float, double, xtd::sinf, mpfr::sin>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sinf(double)") {
+            test_f<float, double, xtd::sinf, mpfr::sin>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::sinf(int)") {
-              test_f<float, int, xtd::sinf, mpfr::sin>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::sinf(int)") {
+            test_f<float, int, xtd::sinf, mpfr::sin>(queue, values, ulps_float);
           }
         }
       }

--- a/test/sinh/sinh_t.sycl.cc
+++ b/test/sinh/sinh_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::sinh", "[sinh][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::sinh(float)") {
-              test<float, float, xtd::sinh, mpfr::sinh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sinh(float)") {
+            test<float, float, xtd::sinh, mpfr::sinh>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::sinh(double)") {
-              test<double, double, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::sinh(double)") {
+            test<double, double, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::sinh(int)") {
-              test<double, int, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::sinh(int)") {
+            test<double, int, xtd::sinh, mpfr::sinh>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::sinhf(float)") {
-              test_f<float, float, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sinhf(float)") {
+            test_f<float, float, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::sinhf(double)") {
-              test_f<float, double, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sinhf(double)") {
+            test_f<float, double, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::sinhf(int)") {
-              test_f<float, int, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::sinhf(int)") {
+            test_f<float, int, xtd::sinhf, mpfr::sinh>(queue, values, ulps_float);
           }
         }
       }

--- a/test/sinh/sinh_t.sycl.cc
+++ b/test/sinh/sinh_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 2;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 4;
+constexpr int ulps_double = 4;
 
 TEST_CASE("xtd::sinh", "[sinh][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/sqrt/sqrt_t.sycl.cc
+++ b/test/sqrt/sqrt_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::sqrt", "[sqrt][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::sqrt(float)") {
-              test<float, float, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sqrt(float)") {
+            test<float, float, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::sqrt(double)") {
-              test<double, double, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::sqrt(double)") {
+            test<double, double, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::sqrt(int)") {
-              test<double, int, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::sqrt(int)") {
+            test<double, int, xtd::sqrt, mpfr::sqrt>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::sqrtf(float)") {
-              test_f<float, float, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sqrtf(float)") {
+            test_f<float, float, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::sqrtf(double)") {
-              test_f<float, double, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::sqrtf(double)") {
+            test_f<float, double, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::sqrtf(int)") {
-              test_f<float, int, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::sqrtf(int)") {
+            test_f<float, int, xtd::sqrtf, mpfr::sqrt>(queue, values, ulps_float);
           }
         }
       }

--- a/test/tan/tan_t.sycl.cc
+++ b/test/tan/tan_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::tan", "[tan][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::tan(float)") {
-              test<float, float, xtd::tan, mpfr::tan>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::tan(float)") {
+            test<float, float, xtd::tan, mpfr::tan>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::tan(double)") {
-              test<double, double, xtd::tan, mpfr::tan>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::tan(double)") {
+            test<double, double, xtd::tan, mpfr::tan>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::tan(int)") {
-              test<double, int, xtd::tan, mpfr::tan>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::tan(int)") {
+            test<double, int, xtd::tan, mpfr::tan>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::tanf(float)") {
-              test_f<float, float, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::tanf(float)") {
+            test_f<float, float, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::tanf(double)") {
-              test_f<float, double, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::tanf(double)") {
+            test_f<float, double, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::tanf(int)") {
-              test_f<float, int, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::tanf(int)") {
+            test_f<float, int, xtd::tanf, mpfr::tan>(queue, values, ulps_float);
           }
         }
       }

--- a/test/tan/tan_t.sycl.cc
+++ b/test/tan/tan_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 4;
-constexpr int ulps_double = 2;
+constexpr int ulps_float = 5;
+constexpr int ulps_double = 5;
 
 TEST_CASE("xtd::tan", "[tan][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/tanh/tanh_t.sycl.cc
+++ b/test/tanh/tanh_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::tanh", "[tanh][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::tanh(float)") {
-              test<float, float, xtd::tanh, mpfr::tanh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::tanh(float)") {
+            test<float, float, xtd::tanh, mpfr::tanh>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::tanh(double)") {
-              test<double, double, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::tanh(double)") {
+            test<double, double, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::tanh(int)") {
-              test<double, int, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::tanh(int)") {
+            test<double, int, xtd::tanh, mpfr::tanh>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::tanhf(float)") {
-              test_f<float, float, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::tanhf(float)") {
+            test_f<float, float, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::tanhf(double)") {
-              test_f<float, double, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::tanhf(double)") {
+            test_f<float, double, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::tanhf(int)") {
-              test_f<float, int, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::tanhf(int)") {
+            test_f<float, int, xtd::tanhf, mpfr::tanh>(queue, values, ulps_float);
           }
         }
       }

--- a/test/tanh/tanh_t.sycl.cc
+++ b/test/tanh/tanh_t.sycl.cc
@@ -27,8 +27,8 @@
 #include "common/sycl_test.h"
 #include "common/math_inputs.h"
 
-constexpr int ulps_float = 1;
-constexpr int ulps_double = 1;
+constexpr int ulps_float = 5;
+constexpr int ulps_double = 5;
 
 TEST_CASE("xtd::tanh", "[tanh][sycl]") {
   std::vector<double> values = generate_input_values();

--- a/test/trunc/trunc_t.sycl.cc
+++ b/test/trunc/trunc_t.sycl.cc
@@ -37,39 +37,34 @@ TEST_CASE("xtd::trunc", "[trunc][sycl]") {
     SECTION(platform.get_info<sycl::info::platform::name>()) {
       for (const auto &device : platform.get_devices()) {
         SECTION(device.get_info<sycl::info::device::name>()) {
-          try {
-            sycl::queue queue{device, sycl::property::queue::in_order()};
+          if (not device.has(sycl::aspect::fp64)) {
+            std::cout << "The device " << device.get_info<sycl::info::device::name>()
+                      << " does not support double precision floating point operations, some tests will be skipped.\n";
+          }
+          sycl::queue queue{device, sycl::property::queue::in_order()};
 
-            SECTION("float xtd::trunc(float)") {
-              test<float, float, xtd::trunc, mpfr::trunc>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::trunc(float)") {
+            test<float, float, xtd::trunc, mpfr::trunc>(queue, values, ulps_float);
+          }
 
-            SECTION("double xtd::trunc(double)") {
-              test<double, double, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::trunc(double)") {
+            test<double, double, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
+          }
 
-            SECTION("double xtd::trunc(int)") {
-              test<double, int, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
-            }
+          SECTION("double xtd::trunc(int)") {
+            test<double, int, xtd::trunc, mpfr::trunc>(queue, values, ulps_double);
+          }
 
-            SECTION("float xtd::truncf(float)") {
-              test_f<float, float, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::truncf(float)") {
+            test_f<float, float, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::truncf(double)") {
-              test_f<float, double, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
-            }
+          SECTION("float xtd::truncf(double)") {
+            test_f<float, double, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
+          }
 
-            SECTION("float xtd::truncf(int)") {
-              test_f<float, int, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
-            }
-
-          } catch (sycl::exception const &e) {
-            std::cerr << "SYCL exception:\n"
-                      << e.what() << "\ncaught while running on platform "
-                      << platform.get_info<sycl::info::platform::name>() << ", device "
-                      << device.get_info<sycl::info::device::name>() << '\n';
-            continue;
+          SECTION("float xtd::truncf(int)") {
+            test_f<float, int, xtd::truncf, mpfr::trunc>(queue, values, ulps_float);
           }
         }
       }


### PR DESCRIPTION
Update the SYCL tests to use the accuracy from the OpenCL specification, and skip tests that require double precision floating point number on devices that do not support them.  