### PR TITLE
Implement integer division functions

### DIFF
--- a/include/xtd/stdlib.h
+++ b/include/xtd/stdlib.h
@@ -8,3 +8,6 @@
 
 // Miscellaneous algorithms and math
 #include "stdlib/abs.h"
+#include "stdlib/div.h"
+#include "stdlib/ldiv.h"
+#include "stdlib/lldiv.h"

--- a/include/xtd/stdlib/div.h
+++ b/include/xtd/stdlib/div.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <cstdlib>
+
+#include "xtd/internal/defines.h"
+
+namespace xtd {
+
+  /* Computes the quotient and reminder of the integer division `numerator / denominator`,
+   * and returns them in the `quot` and `rem` members of an `div_t` struct.
+   * If the denominator is 0, does not raise a floating point exception and returns { 0, 0 }.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr ::div_t div(int numerator, int denominator) {
+    ::div_t result;
+    if (denominator != 0) {
+      result.quot = numerator / denominator;
+      result.rem = numerator % denominator;
+    } else {
+      result.quot = 0;
+      result.rem = 0;
+    }
+    return result;
+  }
+
+}  // namespace xtd

--- a/include/xtd/stdlib/ldiv.h
+++ b/include/xtd/stdlib/ldiv.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <cstdlib>
+
+#include "xtd/internal/defines.h"
+
+namespace xtd {
+
+  /* Computes the quotient and reminder of the integer division `numerator / denominator`,
+   * and returns them in the `quot` and `rem` members of an `ldiv_t` struct.
+   * If the denominator is 0, does not raise a floating point exception and returns { 0, 0 }.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr ::ldiv_t ldiv(long numerator, long denominator) {
+    ::ldiv_t result;
+    if (denominator != 0) {
+      result.quot = numerator / denominator;
+      result.rem = numerator % denominator;
+    } else {
+      result.quot = 0;
+      result.rem = 0;
+    }
+    return result;
+  }
+
+}  // namespace xtd

--- a/include/xtd/stdlib/lldiv.h
+++ b/include/xtd/stdlib/lldiv.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <cstdlib>
+
+#include "xtd/internal/defines.h"
+
+namespace xtd {
+
+  /* Computes the quotient and reminder of the integer division `numerator / denominator`,
+   * and returns them in the `quot` and `rem` members of an `lldiv_t` struct.
+   * If the denominator is 0, does not raise a floating point exception and returns { 0, 0 }.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr ::lldiv_t lldiv(long long numerator, long long denominator) {
+    ::lldiv_t result;
+    if (denominator != 0) {
+      result.quot = numerator / denominator;
+      result.rem = numerator % denominator;
+    } else {
+      result.quot = 0;
+      result.rem = 0;
+    }
+    return result;
+  }
+
+}  // namespace xtd

--- a/test/common/cpu/validate_div.h
+++ b/test/common/cpu/validate_div.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+// C++ standard headers
+#include <concepts>
+#include <iomanip>
+#include <iostream>
+#include <span>
+#include <type_traits>
+
+// test headers
+#include "common/compare.h"
+#include "common/cpu/inputs.h"
+#include "common/halton.h"
+
+namespace test::cpu {
+
+  template <typename T>
+  concept DivResultType = requires(T t) {
+    // C struct
+    requires std::is_standard_layout_v<T>;
+
+    // quot data member
+    t.quot;
+    requires std::integral<decltype(T::quot)>;
+
+    // rem data member
+    t.rem;
+    requires std::integral<decltype(T::rem)>;
+
+    // members type
+    requires std::same_as<decltype(T::quot), decltype(T::rem)>;
+  };
+
+  template <typename T>
+  struct detailed {
+    constexpr detailed(T value) : value_{value} {
+    }
+
+    T value_;
+  };
+
+  template <std::integral T>
+  std::ostream& operator<<(std::ostream& out, detailed<T> const& val) {
+    out << val.value_;
+    return out;
+  }
+
+  template <DivResultType T>
+  std::ostream& operator<<(std::ostream& out, detailed<T> const& val) {
+    out << '[' << val.value_.quot << ", " << val.value_.rem << ']';
+    return out;
+  }
+
+  template <DivResultType ResultType,
+            std::integral InputType,
+            ResultType (*XtdFunc)(InputType, InputType),
+            ResultType (*RefFunc)(InputType, InputType)>
+  inline void validate_div(const Device& device) {
+    std::span<const InputType> values = inputs().values<InputType>();
+    unsigned int size = values.size();
+    for (unsigned int t = 0; t < size; ++t) {
+      // generate a low-discrepancy deterministic sequence over [0, size)×[0, size)
+      auto [i, j] = halton<2>(t, size);
+      InputType x = values[i];
+      InputType y = values[j];
+      // compute the result of the xtd function
+      ResultType result = XtdFunc(x, y);
+      // compute the reference
+      ResultType reference = RefFunc(x, y);
+      // log the comparison
+      INFO("input: " << detailed(x) << ", " << detailed(y) << "\nxtd result: " << detailed(result)
+                     << "\nreference:  " << detailed(reference) << '\n');
+      // compare the result with the reference
+      compare(result.quot, reference.quot);
+      compare(result.rem, reference.rem);
+    }
+  }
+
+}  // namespace test::cpu

--- a/test/common/cuda/validate_div.h
+++ b/test/common/cuda/validate_div.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+// C++ standard headers
+#include <iomanip>
+#include <iostream>
+#include <vector>
+#include <type_traits>
+
+// CUDA headers
+#include <cuda_runtime.h>
+
+// xtd headers
+#include <xtd/algorithm.h>
+
+// test headers
+#include "common/compare.h"
+#include "common/cuda/cuda_check.h"
+#include "common/cuda/device.h"
+#include "common/cuda/inputs.h"
+#include "common/halton.h"
+#include "common/mpfr.h"
+
+namespace test::cuda {
+
+  template <typename ResultType, typename InputType, ResultType (*XtdFunc)(InputType, InputType)>
+  __global__ static void kernel_div(InputType const* input, ResultType* result, unsigned int size) {
+    const int thread = blockDim.x * blockIdx.x + threadIdx.x;
+    const int stride = blockDim.x * gridDim.x;
+    for (unsigned int t = thread; t < size; t += stride) {
+      // generate a low-discrepancy deterministic sequence over [0, size)*[0, size)
+      auto [i, j] = halton<2>(t, size);
+      InputType x = input[i];
+      InputType y = input[j];
+      result[t] = XtdFunc(x, y);
+    }
+  }
+
+  template <typename T>
+  concept DivResultType = requires(T t) {
+    // C struct
+    requires std::is_standard_layout_v<T>;
+
+    // quot data member
+    t.quot;
+    requires std::integral<decltype(T::quot)>;
+
+    // rem data member
+    t.rem;
+    requires std::integral<decltype(T::rem)>;
+
+    // members type
+    requires std::same_as<decltype(T::quot), decltype(T::rem)>;
+  };
+
+  template <typename T>
+  struct detailed {
+    constexpr detailed(T value) : value_{value} {
+    }
+
+    T value_;
+  };
+
+  template <std::integral T>
+  std::ostream& operator<<(std::ostream& out, detailed<T> const& val) {
+    out << val.value_;
+    return out;
+  }
+
+  template <DivResultType T>
+  std::ostream& operator<<(std::ostream& out, detailed<T> const& val) {
+    out << '[' << val.value_.quot << ", " << val.value_.rem << ']';
+    return out;
+  }
+
+  template <DivResultType ResultType,
+            std::integral InputType,
+            ResultType (*XtdFunc)(InputType, InputType),
+            ResultType (*RefFunc)(InputType, InputType)>
+  inline void validate_div(const Device& device) {
+    cudaStream_t queue = device.queue();
+    const Inputs& input = inputs(device);
+    unsigned int size = input.size();
+    std::span<const InputType> values_h = input.values_h<InputType>();
+    std::span<const InputType> values_d = input.values_d<InputType>();
+
+    // allocate memory for the results and fill it with zeroes
+    std::vector<ResultType> result_h(size);
+    ResultType* result_d;
+    CUDA_CHECK(cudaMallocAsync(&result_d, size * sizeof(ResultType), queue));
+    CUDA_CHECK(cudaMemsetAsync(result_d, 0x00, size * sizeof(ResultType), queue));
+
+    // execute the xtd function on the GPU
+    kernel_div<ResultType, InputType, XtdFunc><<<8, 64, 0, queue>>>(values_d.data(), result_d, size);
+    CUDA_CHECK(cudaGetLastError());
+
+    // copy the results back to the host and free the GPU memory
+    CUDA_CHECK(cudaMemcpyAsync(result_h.data(), result_d, size * sizeof(ResultType), cudaMemcpyDeviceToHost, queue));
+    CUDA_CHECK(cudaFreeAsync(result_d, queue));
+    CUDA_CHECK(cudaStreamSynchronize(queue));
+
+    for (unsigned int t = 0; t < size; ++t) {
+      // generate a low-discrepancy deterministic sequence over [0, size)*[0, size)
+      auto [i, j] = halton<2>(t, size);
+      InputType x = values_h[i];
+      InputType y = values_h[j];
+      // read the result of the xtd function
+      ResultType result = result_h[t];
+      // compute the reference
+      ResultType reference = RefFunc(x, y);
+      // log the comparison
+      INFO("index: " << t << "\ninput: " << detailed(x) << ", " << detailed(y) << ", "
+                     << "\nxtd result: " << detailed(result) << "\nreference:  " << detailed(reference) << '\n');
+      // compare the result with the reference
+      compare(result.quot, reference.quot);
+      compare(result.rem, reference.rem);
+    }
+  }
+
+}  // namespace test::cuda

--- a/test/common/hip/validate_div.h
+++ b/test/common/hip/validate_div.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+// C++ standard headers
+#include <iomanip>
+#include <iostream>
+#include <vector>
+#include <type_traits>
+
+// HIP headers
+#include <hip/hip_runtime.h>
+
+// xtd headers
+#include <xtd/algorithm.h>
+
+// test headers
+#include "common/compare.h"
+#include "common/hip/hip_check.h"
+#include "common/hip/device.h"
+#include "common/hip/inputs.h"
+#include "common/halton.h"
+#include "common/mpfr.h"
+
+namespace test::hip {
+
+  template <typename ResultType, typename InputType, ResultType (*XtdFunc)(InputType, InputType)>
+  __global__ static void kernel_div(InputType const* input, ResultType* result, unsigned int size) {
+    const int thread = blockDim.x * blockIdx.x + threadIdx.x;
+    const int stride = blockDim.x * gridDim.x;
+    for (unsigned int t = thread; t < size; t += stride) {
+      // generate a low-discrepancy deterministic sequence over [0, size)*[0, size)
+      auto [i, j] = halton<2>(t, size);
+      InputType x = input[i];
+      InputType y = input[j];
+      result[t] = XtdFunc(x, y);
+    }
+  }
+
+  template <typename T>
+  concept DivResultType = requires(T t) {
+    // C struct
+    requires std::is_standard_layout_v<T>;
+
+    // quot data member
+    t.quot;
+    requires std::integral<decltype(T::quot)>;
+
+    // rem data member
+    t.rem;
+    requires std::integral<decltype(T::rem)>;
+
+    // members type
+    requires std::same_as<decltype(T::quot), decltype(T::rem)>;
+  };
+
+  template <typename T>
+  struct detailed {
+    constexpr detailed(T value) : value_{value} {
+    }
+
+    T value_;
+  };
+
+  template <std::integral T>
+  std::ostream& operator<<(std::ostream& out, detailed<T> const& val) {
+    out << val.value_;
+    return out;
+  }
+
+  template <DivResultType T>
+  std::ostream& operator<<(std::ostream& out, detailed<T> const& val) {
+    out << '[' << val.value_.quot << ", " << val.value_.rem << ']';
+    return out;
+  }
+
+  template <DivResultType ResultType,
+            std::integral InputType,
+            ResultType (*XtdFunc)(InputType, InputType),
+            ResultType (*RefFunc)(InputType, InputType)>
+  inline void validate_div(const Device& device) {
+    hipStream_t queue = device.queue();
+    const Inputs& input = inputs(device);
+    unsigned int size = input.size();
+    std::span<const InputType> values_h = input.values_h<InputType>();
+    std::span<const InputType> values_d = input.values_d<InputType>();
+
+    // allocate memory for the results and fill it with zeroes
+    std::vector<ResultType> result_h(size);
+    ResultType* result_d;
+    HIP_CHECK(hipMallocAsync(&result_d, size * sizeof(ResultType), queue));
+    HIP_CHECK(hipMemsetAsync(result_d, 0x00, size * sizeof(ResultType), queue));
+
+    // execute the xtd function on the GPU
+    kernel_div<ResultType, InputType, XtdFunc><<<8, 64, 0, queue>>>(values_d.data(), result_d, size);
+    HIP_CHECK(hipGetLastError());
+
+    // copy the results back to the host and free the GPU memory
+    HIP_CHECK(hipMemcpyAsync(result_h.data(), result_d, size * sizeof(ResultType), hipMemcpyDeviceToHost, queue));
+    HIP_CHECK(hipFreeAsync(result_d, queue));
+    HIP_CHECK(hipStreamSynchronize(queue));
+
+    for (unsigned int t = 0; t < size; ++t) {
+      // generate a low-discrepancy deterministic sequence over [0, size)*[0, size)
+      auto [i, j] = halton<2>(t, size);
+      InputType x = values_h[i];
+      InputType y = values_h[j];
+      // read the result of the xtd function
+      ResultType result = result_h[t];
+      // compute the reference
+      ResultType reference = RefFunc(x, y);
+      // log the comparison
+      INFO("index: " << t << "\ninput: " << detailed(x) << ", " << detailed(y) << ", "
+                     << "\nxtd result: " << detailed(result) << "\nreference:  " << detailed(reference) << '\n');
+      // compare the result with the reference
+      compare(result.quot, reference.quot);
+      compare(result.rem, reference.rem);
+    }
+  }
+
+}  // namespace test::hip

--- a/test/common/sycl/validate_div.h
+++ b/test/common/sycl/validate_div.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+// C++ standard headers
+#include <iomanip>
+#include <iostream>
+#include <type_traits>
+#include <vector>
+
+// SYCL headers
+#include <sycl/sycl.hpp>
+
+// xtd headers
+#include <xtd/algorithm.h>
+
+// test headers
+#include "common/compare.h"
+#include "common/halton.h"
+#include "common/mpfr.h"
+#include "common/sycl/device.h"
+#include "common/sycl/inputs.h"
+#include "common/sycl/platform.h"
+
+namespace test::sycl {
+
+  template <typename T>
+  concept DivResultType = requires(T t) {
+    // C struct
+    requires std::is_standard_layout_v<T>;
+
+    // quot data member
+    t.quot;
+    requires std::integral<decltype(T::quot)>;
+
+    // rem data member
+    t.rem;
+    requires std::integral<decltype(T::rem)>;
+
+    // members type
+    requires std::same_as<decltype(T::quot), decltype(T::rem)>;
+  };
+
+  template <typename T>
+  struct detailed {
+    constexpr detailed(T value) : value_{value} {
+    }
+
+    T value_;
+  };
+
+  template <std::integral T>
+  std::ostream& operator<<(std::ostream& out, detailed<T> const& val) {
+    out << val.value_;
+    return out;
+  }
+
+  template <DivResultType T>
+  std::ostream& operator<<(std::ostream& out, detailed<T> const& val) {
+    out << '[' << val.value_.quot << ", " << val.value_.rem << ']';
+    return out;
+  }
+
+  template <DivResultType ResultType,
+            std::integral InputType,
+            ResultType (*XtdFunc)(InputType, InputType),
+            ResultType (*RefFunc)(InputType, InputType)>
+  inline void validate_div(const Platform& platform, const Device& device) try {
+    if constexpr (std::is_same_v<InputType, double>) {
+      if (not device.device().has(::sycl::aspect::fp64)) {
+        INFO("The device does not support double precision floating point operations, the test will be skipped.");
+        return;
+      }
+    }
+
+    const Inputs& input = inputs(platform, device);
+    unsigned int size = input.size();
+    std::span<const InputType> values_h = input.values_h<InputType>();
+    std::span<const InputType> values_d = input.values_d<InputType>();
+
+    // Allocate memory for the results and fill it with zeroes.
+    std::vector<ResultType> result_h(size, ResultType{0, 0});
+    ResultType* result_d = ::sycl::malloc_device<ResultType>(size, device.queue());
+    device.queue().fill(result_d, ResultType{0, 0}, size);
+
+    // Execute the xtd function on the SYCL device.
+    device.queue().submit([&](::sycl::handler& cgh) {
+      cgh.parallel_for(::sycl::range<1>(size), [=](::sycl::id<1> t) {
+        // Generate a low-discrepancy deterministic sequence over [0, size)×[0, size).
+        auto [i, j] = halton<2>(static_cast<size_t>(t), size);
+        InputType x = values_d[i];
+        InputType y = values_d[j];
+        result_d[t] = static_cast<ResultType>(XtdFunc(x, y));
+      });
+    });
+
+    // Copy the results back to the host and free the device memory.
+    device.queue().copy(result_d, result_h.data(), size);
+    device.queue().wait();
+    ::sycl::free(result_d, device.queue());
+
+    for (unsigned int t = 0; t < size; ++t) {
+      // generate a low-discrepancy deterministic sequence over [0, size)×[0, size)
+      auto [i, j] = halton<2>(t, size);
+      InputType x = values_h[i];
+      InputType y = values_h[j];
+      // read the result of the xtd function
+      ResultType result = result_h[t];
+      // compute the reference
+      ResultType reference = RefFunc(x, y);
+      // log the comparison
+      INFO("index: " << t << "\ninput: " << detailed(x) << ", " << detailed(y) << "\nxtd result: " << detailed(result)
+                     << "\nreference:  " << detailed(reference) << '\n');
+      // compare the result with the reference
+      compare(result.quot, reference.quot);
+      compare(result.rem, reference.rem);
+    }
+  } catch (::sycl::exception const& e) {
+    std::cerr << "SYCL exception:\n"
+              << e.what() << "\ncaught while running on platform "
+              << platform.platform().get_info<::sycl::info::platform::name>() << ", device "
+              << device.device().get_info<::sycl::info::device::name>() << '\n';
+    std::exit(EXIT_FAILURE);
+  }
+
+}  // namespace test::sycl

--- a/test/src/stdlib/div/div_t.cc
+++ b/test/src/stdlib/div/div_t.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/div.h"
+
+// test headers
+#include "common/cpu/device.h"
+#include "common/cpu/validate_div.h"
+#include "reference_div.h"
+
+TEST_CASE("xtd::div", "[div][cpu]") {
+  const auto& device = test::cpu::device();
+  DYNAMIC_SECTION("CPU: " << device.name()) {
+    SECTION("div_t xtd::div(int, int)") {
+      validate_div<div_t, int, xtd::div, reference_div>(device);
+    }
+  }
+}

--- a/test/src/stdlib/div/div_t.cu
+++ b/test/src/stdlib/div/div_t.cu
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/div.h"
+
+// test headers
+#include "common/cuda/platform.h"
+#include "common/cuda/validate_div.h"
+#include "reference_div.h"
+
+TEST_CASE("xtd::div", "[fdim][cuda]") {
+  const auto& platform = test::cuda::platform();
+  DYNAMIC_SECTION("CUDA platform: " << platform.name()) {
+    for (const auto& device : platform.devices()) {
+      DYNAMIC_SECTION("CUDA device " << device.index() << ": " << device.name()) {
+        SECTION("div_t xtd::div(int, int)") {
+          validate_div<div_t, int, xtd::div, reference_div>(device);
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/div/div_t.hip.cc
+++ b/test/src/stdlib/div/div_t.hip.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/div.h"
+
+// test headers
+#include "common/hip/platform.h"
+#include "common/hip/validate_div.h"
+#include "reference_div.h"
+
+TEST_CASE("xtd::div", "[fdim][hip]") {
+  const auto& platform = test::hip::platform();
+  DYNAMIC_SECTION("HIP platform: " << platform.name()) {
+    for (const auto& device : platform.devices()) {
+      DYNAMIC_SECTION("HIP device " << device.index() << ": " << device.name()) {
+        SECTION("div_t xtd::div(int, int)") {
+          validate_div<div_t, int, xtd::div, reference_div>(device);
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/div/div_t.sycl.cc
+++ b/test/src/stdlib/div/div_t.sycl.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/div.h"
+
+// test headers
+#include "common/sycl/device.h"
+#include "common/sycl/platform.h"
+#include "common/sycl/validate_div.h"
+#include "reference_div.h"
+
+TEST_CASE("xtd::div", "[fdim][sycl]") {
+  for (const auto &platform : test::sycl::platforms()) {
+    DYNAMIC_SECTION("SYCL platform " << platform.index() << ": " << platform.name()) {
+      for (const auto &device : platform.devices()) {
+        DYNAMIC_SECTION("SYCL device " << platform.index() << '.' << device.index() << ": " << device.name()) {
+          SECTION("div_t xtd::div(int, int)") {
+            validate_div<div_t, int, xtd::div, reference_div>(platform, device);
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/div/reference_div.h
+++ b/test/src/stdlib/div/reference_div.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cstdlib>
+
+inline std::div_t reference_div(int n, int d) {
+  // If the denominator is 0, return {0, 0} instead of raising a floating point exception.
+  return d ? std::div(n, d) : std::div_t{0, 0};
+}

--- a/test/src/stdlib/ldiv/ldiv_t.cc
+++ b/test/src/stdlib/ldiv/ldiv_t.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/ldiv.h"
+
+// test headers
+#include "common/cpu/device.h"
+#include "common/cpu/validate_div.h"
+#include "reference_ldiv.h"
+
+TEST_CASE("xtd::ldiv", "[ldiv][cpu]") {
+  const auto& device = test::cpu::device();
+  DYNAMIC_SECTION("CPU: " << device.name()) {
+    SECTION("ldiv_t xtd::ldiv(long, long)") {
+      validate_div<ldiv_t, long, xtd::ldiv, reference_ldiv>(device);
+    }
+  }
+}

--- a/test/src/stdlib/ldiv/ldiv_t.cu
+++ b/test/src/stdlib/ldiv/ldiv_t.cu
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/ldiv.h"
+
+// test headers
+#include "common/cuda/platform.h"
+#include "common/cuda/validate_div.h"
+#include "reference_ldiv.h"
+
+TEST_CASE("xtd::ldiv", "[fdim][cuda]") {
+  const auto& platform = test::cuda::platform();
+  DYNAMIC_SECTION("CUDA platform: " << platform.name()) {
+    for (const auto& device : platform.devices()) {
+      DYNAMIC_SECTION("CUDA device " << device.index() << ": " << device.name()) {
+        SECTION("ldiv_t xtd::ldiv(long, long)") {
+          validate_div<ldiv_t, long, xtd::ldiv, reference_ldiv>(device);
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/ldiv/ldiv_t.hip.cc
+++ b/test/src/stdlib/ldiv/ldiv_t.hip.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/ldiv.h"
+
+// test headers
+#include "common/hip/platform.h"
+#include "common/hip/validate_div.h"
+#include "reference_ldiv.h"
+
+TEST_CASE("xtd::ldiv", "[fdim][hip]") {
+  const auto& platform = test::hip::platform();
+  DYNAMIC_SECTION("HIP platform: " << platform.name()) {
+    for (const auto& device : platform.devices()) {
+      DYNAMIC_SECTION("HIP device " << device.index() << ": " << device.name()) {
+        SECTION("ldiv_t xtd::ldiv(long, long)") {
+          validate_div<ldiv_t, long, xtd::ldiv, reference_ldiv>(device);
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/ldiv/ldiv_t.sycl.cc
+++ b/test/src/stdlib/ldiv/ldiv_t.sycl.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/ldiv.h"
+
+// test headers
+#include "common/sycl/device.h"
+#include "common/sycl/platform.h"
+#include "common/sycl/validate_div.h"
+#include "reference_ldiv.h"
+
+TEST_CASE("xtd::ldiv", "[fdim][sycl]") {
+  for (const auto &platform : test::sycl::platforms()) {
+    DYNAMIC_SECTION("SYCL platform " << platform.index() << ": " << platform.name()) {
+      for (const auto &device : platform.devices()) {
+        DYNAMIC_SECTION("SYCL device " << platform.index() << '.' << device.index() << ": " << device.name()) {
+          SECTION("ldiv_t xtd::ldiv(long, long)") {
+            validate_div<ldiv_t, long, xtd::ldiv, reference_ldiv>(platform, device);
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/ldiv/reference_ldiv.h
+++ b/test/src/stdlib/ldiv/reference_ldiv.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cstdlib>
+
+inline std::ldiv_t reference_ldiv(long n, long d) {
+  // If the denominator is 0, return {0, 0} instead of raising a floating point exception.
+  return d ? std::ldiv(n, d) : std::ldiv_t{0, 0};
+}

--- a/test/src/stdlib/lldiv/lldiv_t.cc
+++ b/test/src/stdlib/lldiv/lldiv_t.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/lldiv.h"
+
+// test headers
+#include "common/cpu/device.h"
+#include "common/cpu/validate_div.h"
+#include "reference_lldiv.h"
+
+TEST_CASE("xtd::lldiv", "[lldiv][cpu]") {
+  const auto& device = test::cpu::device();
+  DYNAMIC_SECTION("CPU: " << device.name()) {
+    SECTION("lldiv_t xtd::lldiv(long long, long long)") {
+      validate_div<lldiv_t, long long, xtd::lldiv, reference_lldiv>(device);
+    }
+  }
+}

--- a/test/src/stdlib/lldiv/lldiv_t.cu
+++ b/test/src/stdlib/lldiv/lldiv_t.cu
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/lldiv.h"
+
+// test headers
+#include "common/cuda/platform.h"
+#include "common/cuda/validate_div.h"
+#include "reference_lldiv.h"
+
+TEST_CASE("xtd::lldiv", "[fdim][cuda]") {
+  const auto& platform = test::cuda::platform();
+  DYNAMIC_SECTION("CUDA platform: " << platform.name()) {
+    for (const auto& device : platform.devices()) {
+      DYNAMIC_SECTION("CUDA device " << device.index() << ": " << device.name()) {
+        SECTION("lldiv_t xtd::lldiv(long long, long long)") {
+          validate_div<lldiv_t, long long, xtd::lldiv, reference_lldiv>(device);
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/lldiv/lldiv_t.hip.cc
+++ b/test/src/stdlib/lldiv/lldiv_t.hip.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/lldiv.h"
+
+// test headers
+#include "common/hip/platform.h"
+#include "common/hip/validate_div.h"
+#include "reference_lldiv.h"
+
+TEST_CASE("xtd::lldiv", "[fdim][hip]") {
+  const auto& platform = test::hip::platform();
+  DYNAMIC_SECTION("HIP platform: " << platform.name()) {
+    for (const auto& device : platform.devices()) {
+      DYNAMIC_SECTION("HIP device " << device.index() << ": " << device.name()) {
+        SECTION("lldiv_t xtd::lldiv(long long, long long)") {
+          validate_div<lldiv_t, long long, xtd::lldiv, reference_lldiv>(device);
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/lldiv/lldiv_t.sycl.cc
+++ b/test/src/stdlib/lldiv/lldiv_t.sycl.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/stdlib/lldiv.h"
+
+// test headers
+#include "common/sycl/device.h"
+#include "common/sycl/platform.h"
+#include "common/sycl/validate_div.h"
+#include "reference_lldiv.h"
+
+TEST_CASE("xtd::lldiv", "[fdim][sycl]") {
+  for (const auto &platform : test::sycl::platforms()) {
+    DYNAMIC_SECTION("SYCL platform " << platform.index() << ": " << platform.name()) {
+      for (const auto &device : platform.devices()) {
+        DYNAMIC_SECTION("SYCL device " << platform.index() << '.' << device.index() << ": " << device.name()) {
+          SECTION("lldiv_t xtd::lldiv(long long, long long)") {
+            validate_div<lldiv_t, long long, xtd::lldiv, reference_lldiv>(platform, device);
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/src/stdlib/lldiv/reference_lldiv.h
+++ b/test/src/stdlib/lldiv/reference_lldiv.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cstdlib>
+
+inline std::lldiv_t reference_lldiv(long long n, long long d) {
+  // If the denominator is 0, return {0, 0} instead of raising a floating point exception.
+  return d ? std::lldiv(n, d) : std::lldiv_t{0, 0};
+}


### PR DESCRIPTION
Implement `xtd::div()`, `xtd::ldiv()`, and `xtd::lldiv()`.

**Note**: division by zero is returned as `{0, 0}`, without raising a floating point exception.