### PR TITLE
Implement `xtd::nan()`

### DIFF
--- a/include/xtd/math.h
+++ b/include/xtd/math.h
@@ -16,7 +16,7 @@
 #include "math/fmax.h"
 #include "math/fmin.h"
 #include "math/fdim.h"
-//nan
+#include "math/nan.h"
 
 // Exponential functions
 #include "math/exp.h"

--- a/include/xtd/math/nan.h
+++ b/include/xtd/math/nan.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>, Simone Balducci <simone.balducci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+
+#include "xtd/internal/defines.h"
+
+namespace xtd {
+
+  /* Returns a single precision quiet NaN (Not a Number) value.
+   *
+   * Note: the lower bits of the argument are encoded in the lower bits on the NaN.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr float nanf(uint32_t arg = 0u) {
+    return std::bit_cast<float>(std::bit_cast<uint32_t>(static_cast<float>(NAN)) | arg);
+  }
+
+  /* Returns a double precision quiet NaN (Not a Number) value.
+   *
+   * Note: the lower bits of the argument are encoded in the lower bits on the NaN.
+   */
+  XTD_DEVICE_FUNCTION inline constexpr double nan(uint64_t arg = 0ull) {
+    return std::bit_cast<double>(std::bit_cast<uint64_t>(static_cast<double>(NAN)) | arg);
+  }
+
+}  // namespace xtd

--- a/test/src/math/nan/nan_t.cc
+++ b/test/src/math/nan/nan_t.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++ standard headers
+#include <cmath>
+#include <vector>
+
+// Catch2 headers
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/math/nan.h"
+
+// test headers
+#include "common/cpu/device.h"
+#include "common/cpu/validate.h"
+#include "reference_nan.h"
+
+constexpr int ulps_single = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::nan", "[nan][cpu]") {
+  const auto& device = test::cpu::device();
+  DYNAMIC_SECTION("CPU: " << device.name()) {
+    SECTION("float xtd::nanf(uint32_t)") {
+      validate<float, uint32_t, xtd::nanf, reference_nanf>(device);
+    }
+
+    SECTION("double xtd::nan(uint64_t)") {
+      validate<double, uint64_t, xtd::nan, reference_nan>(device);
+    }
+  }
+}

--- a/test/src/math/nan/nan_t.cu
+++ b/test/src/math/nan/nan_t.cu
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/math/nan.h"
+
+// test headers
+#include "common/cuda/platform.h"
+#include "common/cuda/validate.h"
+#include "reference_nan.h"
+
+constexpr int ulps_single = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::nan", "[nan][cuda]") {
+  const auto& platform = test::cuda::platform();
+  DYNAMIC_SECTION("CUDA platform: " << platform.name()) {
+    for (const auto& device : platform.devices()) {
+      DYNAMIC_SECTION("CUDA device " << device.index() << ": " << device.name()) {
+        SECTION("float xtd::nanf(uint32_t)") {
+          validate<float, uint32_t, xtd::nanf, reference_nanf>(device);
+        }
+
+        SECTION("double xtd::nan(uint64_t)") {
+          validate<double, uint64_t, xtd::nan, reference_nan>(device);
+        }
+      }
+    }
+  }
+}

--- a/test/src/math/nan/nan_t.hip.cc
+++ b/test/src/math/nan/nan_t.hip.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/math/nan.h"
+
+// test headers
+#include "common/hip/platform.h"
+#include "common/hip/validate.h"
+#include "reference_nan.h"
+
+constexpr int ulps_single = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::nan", "[nan][hip]") {
+  const auto& platform = test::hip::platform();
+  DYNAMIC_SECTION("HIP platform: " << platform.name()) {
+    for (const auto& device : platform.devices()) {
+      DYNAMIC_SECTION("HIP device " << device.index() << ": " << device.name()) {
+        SECTION("float xtd::nanf(uint32_t)") {
+          validate<float, uint32_t, xtd::nanf, reference_nanf>(device);
+        }
+
+        SECTION("double xtd::nan(uint64_t)") {
+          validate<double, uint64_t, xtd::nan, reference_nan>(device);
+        }
+      }
+    }
+  }
+}

--- a/test/src/math/nan/nan_t.sycl.cc
+++ b/test/src/math/nan/nan_t.sycl.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>, Aurora Perego <aurora.perego@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Catch2 headers
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include <catch.hpp>
+
+// xtd headers
+#include "xtd/math/nan.h"
+
+// test headers
+#include "common/sycl/device.h"
+#include "common/sycl/platform.h"
+#include "common/sycl/validate.h"
+#include "reference_nan.h"
+
+constexpr int ulps_single = 0;
+constexpr int ulps_double = 0;
+
+TEST_CASE("xtd::nan", "[nan][sycl]") {
+  for (const auto &platform : test::sycl::platforms()) {
+    DYNAMIC_SECTION("SYCL platform " << platform.index() << ": " << platform.name()) {
+      for (const auto &device : platform.devices()) {
+        DYNAMIC_SECTION("SYCL device " << platform.index() << '.' << device.index() << ": " << device.name()) {
+          SECTION("float xtd::nanf(uint32_t)") {
+            validate<float, uint32_t, xtd::nanf, reference_nanf>(platform, device);
+          }
+
+          SECTION("double xtd::nan(uint64_t)") {
+            validate<double, uint64_t, xtd::nan, reference_nan>(platform, device);
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/src/math/nan/reference_nan.h
+++ b/test/src/math/nan/reference_nan.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 European Organization for Nuclear Research (CERN)
+ * Authors: Andrea Bocci <andrea.bocci@cern.ch>
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// C++
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+inline float reference_nanf(uint32_t arg) {
+  constexpr int size = std::numeric_limits<uint32_t>::digits10 + 1;
+  char buffer[size + 1] = {};
+  std::snprintf(buffer, size, "%u", arg);
+  return std::nanf(buffer);
+}
+
+inline double reference_nan(uint64_t arg) {
+  constexpr int size = std::numeric_limits<uint64_t>::digits10 + 1;
+  char buffer[size + 1] = {};
+  std::snprintf(buffer, size, "%lu", arg);
+  return std::nan(buffer);
+}


### PR DESCRIPTION
Returns a single or double precision quiet NaN (Not a Number) value.

**Note**: the argument is currently ignored. This could change in the future, if a use case for a non-default NaN is presented.