### PR TITLE
remove nonexistent `math/abs.h` include

### DIFF
--- a/include/xtd/math.h
+++ b/include/xtd/math.h
@@ -7,7 +7,6 @@
 #pragma once
 
 // Basic operations
-#include "math/abs.h"
 #include "math/fabs.h"
 #include "math/fmod.h"
 #include "math/remainder.h"


### PR DESCRIPTION
The header `math/abs.h` was moved  to different location in #40