### PR TITLE
Mark parameters `[[maybe_unused]]`

### DIFF
--- a/include/xtd/math/isfinite.h
+++ b/include/xtd/math/isfinite.h
@@ -34,7 +34,7 @@ namespace xtd {
 
   /* Returns a non-zero value if the integer argument is finite (which is always the case).
    */
-  XTD_DEVICE_FUNCTION inline constexpr int isfinite(std::integral auto arg) {
+  XTD_DEVICE_FUNCTION inline constexpr int isfinite([[maybe_unused]] std::integral auto arg) {
     return 1;
   }
 

--- a/include/xtd/math/isinf.h
+++ b/include/xtd/math/isinf.h
@@ -40,7 +40,7 @@ namespace xtd {
 
   /* Returns a non-zero value if the integer argument is infinite, which is never the case.
    */
-  XTD_DEVICE_FUNCTION inline constexpr int isinf(std::integral auto arg) {
+  XTD_DEVICE_FUNCTION inline constexpr int isinf([[maybe_unused]] std::integral auto arg) {
     return 0;
   }
 

--- a/include/xtd/math/isnan.h
+++ b/include/xtd/math/isnan.h
@@ -35,7 +35,7 @@ namespace xtd {
   /* Returns a non-zero value if the integer argument is "Not a Number", which
    * is never the case.
    */
-  XTD_DEVICE_FUNCTION inline constexpr int isnan(std::integral auto arg) {
+  XTD_DEVICE_FUNCTION inline constexpr int isnan([[maybe_unused]] std::integral auto arg) {
     return 0;
   }
 

--- a/include/xtd/math/isnormal.h
+++ b/include/xtd/math/isnormal.h
@@ -36,7 +36,7 @@ namespace xtd {
    * Zero is arbitrarily considered "not normal" for consistency with
    * isnormal(0.f) and isnormal(0.)
    */
-  XTD_DEVICE_FUNCTION inline constexpr int isnormal(std::integral auto arg) {
+  XTD_DEVICE_FUNCTION inline constexpr int isnormal([[maybe_unused]] std::integral auto arg) {
     return arg != 0;
   }
 

--- a/include/xtd/math/signbit.h
+++ b/include/xtd/math/signbit.h
@@ -38,7 +38,7 @@ namespace xtd {
     return arg < 0 ? 1 : 0;
   }
 
-  XTD_DEVICE_FUNCTION inline constexpr int signbit(std::unsigned_integral auto arg) {
+  XTD_DEVICE_FUNCTION inline constexpr int signbit([[maybe_unused]] std::unsigned_integral auto arg) {
     return 0;
   }
 

--- a/test/src/math/isfinite/reference_isfinite.h
+++ b/test/src/math/isfinite/reference_isfinite.h
@@ -11,6 +11,6 @@ inline constexpr int reference_isfinite(std::floating_point auto arg) {
   return __builtin_isfinite(arg) ? 1 : 0;
 }
 
-inline constexpr int reference_isfinite(std::integral auto arg) {
+inline constexpr int reference_isfinite([[maybe_unused]] std::integral auto arg) {
   return 1;
 }

--- a/test/src/math/isinf/reference_isinf.h
+++ b/test/src/math/isinf/reference_isinf.h
@@ -11,6 +11,6 @@ inline constexpr int reference_isinf(std::floating_point auto arg) {
   return __builtin_isinf(arg) ? arg > 0 ? 1 : -1 : 0;
 }
 
-inline constexpr int reference_isinf(std::integral auto arg) {
+inline constexpr int reference_isinf([[maybe_unused]] std::integral auto arg) {
   return 0;
 }

--- a/test/src/math/isnan/reference_isnan.h
+++ b/test/src/math/isnan/reference_isnan.h
@@ -11,6 +11,6 @@ inline constexpr int reference_isnan(std::floating_point auto arg) {
   return __builtin_isnan(arg) ? 1 : 0;
 }
 
-inline constexpr int reference_isnan(std::integral auto arg) {
+inline constexpr int reference_isnan([[maybe_unused]] std::integral auto arg) {
   return 0;
 }


### PR DESCRIPTION
Some classifiers have unused parameters which breaks compilation without `-Wno-unused-parameter`. Use the C++ attribute `maybe_unused` (since C++17) to suppresses warnings on unused entities.